### PR TITLE
Performance: Optimise loading time of quiz questions.

### DIFF
--- a/classes/question/bank/performances_column.php
+++ b/classes/question/bank/performances_column.php
@@ -41,7 +41,10 @@ class practice_column extends \core_question\bank\column_base {
 
         global $DB, $USER;
         $this->currentuserid = $USER->id;
-        $cmid = $this->qbank->get_most_specific_context()->instanceid;
+        // Build context, categoryid and cmid here for use later.
+        $context = $this->qbank->get_most_specific_context();
+        $this->categoryid = question_get_default_category($context->id)->id;
+        $cmid = $context->instanceid;
         // TODO: Get StudentQuiz id from infrastructure instead of DB!
         // TODO: Exception handling lookup fails somehow.
         $sq = $DB->get_record('studentquiz', array('coursemodule' => $cmid));
@@ -106,7 +109,8 @@ class practice_column extends \core_question\bank\column_base {
      */
     public function get_extra_joins() {
 
-        $tests = array('qa.responsesummary IS NOT NULL');
+        // Add outer WHERE tests here to limit the dataset to just the module question category.
+        $tests = array('qa.responsesummary IS NOT NULL', 'q.parent = 0', 'q.hidden = 0', 'q.category = ' . $this->categoryid);
         return array('pr' => 'LEFT JOIN ('
             . 'SELECT COUNT(questionid) as practice'
             . ', questionid FROM {question_attempts} qa JOIN {question} q ON qa.questionid = q.id'

--- a/classes/question/bank/tag_column.php
+++ b/classes/question/bank/tag_column.php
@@ -41,6 +41,18 @@ class tag_column extends \core_question\bank\column_base {
     protected $tagfilteractive;
 
     /**
+     * Initialise Parameters for join
+     */
+    protected function init() {
+
+        global $DB;
+
+        // Build context and categoryid here for use later.
+        $context = $this->qbank->get_most_specific_context();
+        $this->categoryid = question_get_default_category($context->id)->id;
+    }
+
+    /**
      * Get column name
      * @return string
      */
@@ -107,7 +119,9 @@ class tag_column extends \core_question\bank\column_base {
                 .' COUNT(*) tags,'
                 .' SUM(CASE WHEN t.name LIKE :searchtag then 1 else 0 end) searchtag'
                 .' FROM {tag} t '
-                .' JOIN {tag_instance} ti ON t.id = ti.tagid'
+                .' JOIN {tag_instance} ti ON (t.id = ti.tagid'
+                .' AND ti.itemid IN (SELECT id FROM {question} q'
+                .'                    WHERE q.category = ' . $this->categoryid . '))'
                 .' WHERE ti.itemtype = \'question\''
                 .' GROUP BY	questionid'
                 . ') tags ON tags.questionid = q.id ');
@@ -118,7 +132,9 @@ class tag_column extends \core_question\bank\column_base {
                 .' COUNT(*) tags,'
                 .' 0 searchtag'
                 .' FROM {tag} t '
-                .' JOIN {tag_instance} ti ON t.id = ti.tagid'
+                .' JOIN {tag_instance} ti ON (t.id = ti.tagid'
+                .' AND ti.itemid IN (SELECT id FROM {question} q'
+                .'                    WHERE q.category = ' . $this->categoryid . '))'
                 .' WHERE ti.itemtype = \'question\''
                 .' GROUP BY	questionid'
                 . ') tags ON tags.questionid = q.id ');


### PR DESCRIPTION
In StudentQuiz v3.0.1 (2018011100) it was found that after you add a question to the quiz, it would take several minutes or longer to load the view page.

This was due to ineffective database queries when gathering the tag and question attempt stats to be displayed on the screen in the question summary table.

Both processes for gather tags and question attempt stats have improved so it can be loaded under a second.