### PR TITLE
Honour anonymity settings in notifications

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -118,7 +118,7 @@ function mod_studentquiz_check_created_permission($cmid) {
  */
 
 function mod_studentquiz_prepare_notify_data($question, $recepient, $actor, $course, $module) {
-
+    global $DB;
     // Prepare message.
     $time = new DateTime('now', core_date::get_user_timezone_object());
 
@@ -146,8 +146,16 @@ function mod_studentquiz_prepare_notify_data($question, $recepient, $actor, $cou
     $data->recepientname     = fullname($recepient);
     $data->recepientusername = $recepient->username;
 
-    // User who triggered the noticication.
-    $data->actorname     = fullname($actor);
+    // Check module settings for anonymity preferences
+    $anonymrank = $DB->get_field('studentquiz', 'anonymrank', array('coursemodule' => $module->id));
+
+    if ($anonymrank == 0) {
+        // Anonymity is off - return user who triggered notification
+        $data->actorname     = fullname($actor);
+    } else {
+        // Anonymity is on - only return Anonymous 
+        $data->actorname     = get_string('creator_anonym_firstname', 'studentquiz');
+    }
     $data->actorusername = $recepient->username;
     return $data;
 }


### PR DESCRIPTION
Fix for #46.

Sorry about that last one.  I am a beginner at moodle programming, but using an assignment operator in a condition is pretty inexcusable! :-S

Beyond the other errors you mentioned, we should also retrieve the "Anonymous" string from the lang file instead, so I did that.  Let's hope this checks out.