### PR TITLE
Enhancement for Question Table Columns

### DIFF
--- a/classes/question/bank/difficulty_level_column.php
+++ b/classes/question/bank/difficulty_level_column.php
@@ -128,10 +128,7 @@ class difficulty_level_column extends \core_question\bank\column_base {
      * @return string field name
      */
     public function is_sortable() {
-        return array(
-            'difficulty' => array('field' => 'dl.difficultylevel', 'title' => get_string('average_column_name', 'studentquiz')),
-            'mydifficulty' => array('field' => 'mydiffs.mydifficulty', 'title' => get_string('mine_column_name', 'studentquiz'))
-        );
+        return $this->renderer->get_is_sortable_difficulty_level_column();
     }
 
     /**

--- a/classes/question/bank/question_name_column.php
+++ b/classes/question/bank/question_name_column.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Representing the question name column
+ *
+ * @package    mod_studentquiz
+ * @copyright  2018 HSR (http://www.hsr.ch)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_studentquiz\bank;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * A column type for the name of the question name.
+ *
+ * @package    mod_studentquiz
+ * @copyright  2018 HSR (http://www.hsr.ch)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class question_name_column extends \core_question\bank\question_name_column {
+
+    protected $renderer;
+    protected $context;
+
+    /**
+     * Loads config of current userid and can see
+     */
+    public function init() {
+        global $PAGE;
+        $this->renderer = $PAGE->get_renderer('mod_studentquiz');
+        $this->context = $this->qbank->get_most_specific_context();
+    }
+
+    /**
+     * Override of base display_content
+     * @param object $question
+     * @param string $rowclasses
+     */
+    protected function display_content($question, $rowclasses) {
+        $labelfor = $this->label_for($question);
+        echo $this->renderer->render_question_name_column($question, $rowclasses, $labelfor);
+    }
+
+}

--- a/classes/question/bank/rate_column.php
+++ b/classes/question/bank/rate_column.php
@@ -110,10 +110,6 @@ class rate_column extends \core_question\bank\column_base {
      * @return string field name
      */
     public function is_sortable() {
-        return array(
-            'rate' => array('field' => 'vo.rate', 'title' => get_string('average_column_name', 'studentquiz')),
-            'myrate' => array('field' => 'myrate.myrate', 'title' => get_string('mine_column_name', 'studentquiz'))
-        );
-
+        return $this->renderer->get_is_sortable_rate_column();
     }
 }

--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -38,6 +38,7 @@ require_once(__DIR__ . '/comments_column.php');
 require_once(__DIR__ . '/approved_column.php');
 require_once(__DIR__ . '/anonym_creator_name_column.php');
 require_once(__DIR__ . '/preview_column.php');
+require_once(__DIR__ . '/question_name_column.php');
 
 /**
  * Module instance settings form
@@ -633,28 +634,6 @@ class studentquiz_bank_view extends \core_question\bank\view {
         ob_end_clean();
         $output .= "</div>\n";
         return $output;
-    }
-
-    /**
-     * (Copy from parent class - modified several code snippets)
-     * @return mixed
-     */
-    protected function wanted_columns() {
-        global $CFG;
-        $CFG->questionbankcolumns = 'checkbox_column,question_type_column,'
-            . 'mod_studentquiz\\bank\\approved_column,'
-            . 'question_name_column,'
-            . 'mod_studentquiz\\bank\\question_text_row,'
-            . 'mod_studentquiz\\bank\\preview_column,'
-            . 'edit_action_column,'
-            . 'delete_action_column,'
-            . 'mod_studentquiz\\bank\\anonym_creator_name_column,'
-            . 'mod_studentquiz\\bank\\tag_column,'
-            . 'mod_studentquiz\\bank\\practice_column,'
-            . 'mod_studentquiz\\bank\\difficulty_level_column,'
-            . 'mod_studentquiz\\bank\\rate_column,'
-            . 'mod_studentquiz\\bank\\comment_column';
-        return parent::wanted_columns();
     }
 
     /**

--- a/renderer.php
+++ b/renderer.php
@@ -527,7 +527,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
      * @param number $average float between 1 to 5 for backgroud bar.
      * @param int $mine between 1 to 5 for number of stars to be yellow
      */
-    private function render_ratingbar($average, $mine, $fillstarson = '#ffc107', $fillstarsoff = '#fff', $fillbaron = '#fff',
+    public function render_ratingbar($average, $mine, $fillstarson = '#ffc107', $fillstarsoff = '#fff', $fillbaron = '#fff',
             $fillbaroff = '#007bff') {
         $output = '';
 
@@ -598,7 +598,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
      * @param $tag
      * @return string
      */
-    private function render_tag($tag) {
+    public function render_tag($tag) {
         $output = '';
 
         $output .= html_writer::tag('span', (strlen($tag->rawname) > 10 ? (substr($tag->rawname, 0, 8) . '...') : $tag->rawname), [
@@ -621,7 +621,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
      * @param int $width
      * @return string
      */
-    private function render_fill_bar($id, $fill, $width = 100) {
+    public function render_fill_bar($id, $fill, $width = 100) {
         $output = '';
 
         $output .= html_writer::empty_tag('rect', [
@@ -651,7 +651,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
      * @param $fill
      * @return string
      */
-    private function render_fill_bolt($stroke, $id, $boltpath, $fill) {
+    public function render_fill_bolt($stroke, $id, $boltpath, $fill) {
         $output = '';
 
         $output .= html_writer::empty_tag('path', [
@@ -674,7 +674,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
      * @param $fill
      * @return string
      */
-    private function render_fill_star($stroke, $id, $starpath, $fill) {
+    public function render_fill_star($stroke, $id, $starpath, $fill) {
         $output = '';
 
         $output .= html_writer::empty_tag('path', [
@@ -686,6 +686,89 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         ]);
 
         return $output;
+    }
+
+    /**
+     * Render the content of question name column.
+     *
+     * @param $question
+     * @param $rowclasses
+     * @param $labelfor
+     * @return string
+     */
+    public function render_question_name_column($question, $rowclasses, $labelfor) {
+        $output = '';
+
+        if ($labelfor) {
+            $output .= html_writer::start_tag('label', ['for' => $labelfor]);
+        }
+        $output .= format_string($question->name);
+        if ($labelfor) {
+            $output .= html_writer::end_tag('label');
+        }
+
+        return $output;
+    }
+
+    /**
+     * Allow to config which columns will be use for Question table.
+     *
+     */
+    public function init_question_table_wanted_columns() {
+        global $CFG;
+        $CFG->questionbankcolumns = 'checkbox_column,question_type_column,'
+                . 'mod_studentquiz\\bank\\approved_column,'
+                . 'mod_studentquiz\\bank\\question_name_column,'
+                . 'mod_studentquiz\\bank\\question_text_row,'
+                . 'mod_studentquiz\\bank\\preview_column,'
+                . 'edit_action_column,'
+                . 'delete_action_column,'
+                . 'mod_studentquiz\\bank\\anonym_creator_name_column,'
+                . 'mod_studentquiz\\bank\\tag_column,'
+                . 'mod_studentquiz\\bank\\practice_column,'
+                . 'mod_studentquiz\\bank\\difficulty_level_column,'
+                . 'mod_studentquiz\\bank\\rate_column,'
+                . 'mod_studentquiz\\bank\\comment_column';
+    }
+
+    /**
+     * Get sortable fields for difficulty level column.
+     *
+     * @return array
+     */
+    public function get_is_sortable_difficulty_level_column() {
+        return [
+                'difficulty' => [
+                        'field' => 'dl.difficultylevel',
+                        'title' => get_string('average_column_name', 'studentquiz'),
+                        'tip' => get_string('average_column_name', 'studentquiz')
+                ],
+                'mydifficulty' => [
+                        'field' => 'mydiffs.mydifficulty',
+                        'title' => get_string('mine_column_name', 'studentquiz'),
+                        'tip' => get_string('mine_column_name', 'studentquiz')
+                ]
+        ];
+    }
+
+    /**
+     * Get sortable fields for rate column.
+     *
+     * @return array
+     */
+    public function get_is_sortable_rate_column() {
+        return [
+                'rate' => [
+                        'field' => 'vo.rate',
+                        'title' => get_string('average_column_name', 'studentquiz'),
+                        'tip' => get_string('average_column_name', 'studentquiz')
+                ],
+                'myrate' => [
+                        'field' => 'myrate.myrate',
+                        'title' => get_string('mine_column_name', 'studentquiz'),
+                        'tip' => get_string('mine_column_name', 'studentquiz')
+                ]
+        ];
     }
 
 }

--- a/view.php
+++ b/view.php
@@ -73,6 +73,9 @@ if (data_submitted()) {
     }
 }
 
+$renderer = $PAGE->get_renderer('mod_studentquiz', 'overview');
+$renderer->init_question_table_wanted_columns();
+
 // Load view.
 $view = new mod_studentquiz_view($course, $context, $cm, $studentquiz, $USER->id);
 $report = new mod_studentquiz_report($cmid);
@@ -86,8 +89,6 @@ $view->process_actions();
 
 // Fire view event for completion API and event API.
 mod_studentquiz_overview_viewed($course, $cm, $context);
-
-$renderer = $PAGE->get_renderer('mod_studentquiz', 'overview');
 
 $regions = $PAGE->blocks->get_regions();
 $PAGE->blocks->add_fake_block($renderer->render_stat_block($report), reset($regions));


### PR DESCRIPTION
Support dynamic config to show/hide specific columns
Support custom tooltips for Difficulty and Rate columns sorting
Added Question name column to allow better customization
Convert some function to public for better override

P/S: Explain for Support custom tooltips for Difficulty and Rate columns sorting:
Column base support custom title and tooltip but there is a bug related to it but there is a but related to it.
I already create a Bug on Moodle Tracker to fix this
https://tracker.moodle.org/browse/MDL-62814
After this was fixed, StudentQuiz sorting can use a custom title and tooltip (previously the title and tooltip is the same)