### PR TITLE
Enhancement: Setting default question types at server-level

### DIFF
--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -164,6 +164,7 @@ $string['settings_removeqbehavior_help'] = 'This info should appear only once du
 $string['settings_allowallqtypes'] = 'Allow all question types';
 $string['settings_allowedqtypes'] = 'Allowed question types';
 $string['settings_allowedqtypes_help'] = 'Here you specify the type of questions that are allowed';
+$string['settings_qtypes_default_new_activity'] = 'The following are default for a new activity';
 
 // Error messages.
 $string['needtoallowatleastoneqtype'] = 'You need to allow at least one question type';
@@ -172,6 +173,7 @@ $string['please_enrole_message'] = 'Please enroll in this course to see your per
 // Admin settings.
 $string['rankingsettingsheader'] = 'Ranking settings';
 $string['rankingsettingsdescription'] = 'The values you set here define the ranking default values that are used in the settings form when you create a new studentquiz.';
+$string['defaultquestiontypessettingsheader'] = 'Default question types';
 
 // Report Dashboard.
 $string['reportquiz_total_attempt'] = 'Times user run the quiz';

--- a/mod_form.php
+++ b/mod_form.php
@@ -46,6 +46,13 @@ class mod_studentquiz_mod_form extends moodleform_mod {
         global $CFG;
 
         $mform = $this->_form;
+        $defaultqtypes = [];
+        $defaultqtypesdefined = false;
+        if ($qtypesdata = get_config('studentquiz', 'defaultqtypes')) {
+            // Default question types already defined in Administration setting.
+            $defaultqtypesdefined = true;
+            $defaultqtypes = explode(',', $qtypesdata);
+        }
 
         // Adding the "general" fieldset, where all the common settings are showed.
         $mform->addElement('header', 'general', get_string('general', 'form'));
@@ -128,8 +135,17 @@ class mod_studentquiz_mod_form extends moodleform_mod {
         $allowedgroup[] =& $mform->createElement('checkbox', "ALL", '', get_string('settings_allowallqtypes', 'studentquiz'));
         foreach (mod_studentquiz_get_question_types() as $qtype => $name) {
             $allowedgroup[] =& $mform->createElement('checkbox', $qtype, '', $name);
+            if ($defaultqtypesdefined && in_array($qtype, $defaultqtypes)) {
+                // Default question types already defined in Administration setting.
+                // This question type was enable by default in Administration setting.
+                $mform->setDefault("allowedqtypes[" . $qtype . "]", 1);
+            }
         }
-        $mform->setDefault("allowedqtypes[ALL]", 1);
+        if (!$defaultqtypesdefined) {
+            // Default question types was not defined in Administration setting.
+            // Set to ALL question types by default.
+            $mform->setDefault("allowedqtypes[ALL]", 1);
+        }
         $mform->addGroup($allowedgroup, 'allowedqtypes', get_string('settings_allowedqtypes', 'studentquiz'));
         $mform->disabledIf('allowedqtypes', "allowedqtypes[ALL]", 'checked');
         $mform->addHelpButton('allowedqtypes', 'settings_allowedqtypes', 'studentquiz');

--- a/settings.php
+++ b/settings.php
@@ -24,6 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
+require_once(__DIR__ . '/locallib.php');
+
 if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_heading(
         'studentquiz/ratingsettings',
@@ -76,5 +78,25 @@ if ($ADMIN->fulltree) {
             '1'
         ));
     }
+
+    $settings->add(new admin_setting_heading(
+            'studentquiz/defaultquestiontypessettings',
+            get_string('defaultquestiontypessettingsheader', 'studentquiz'),
+            ''
+    ));
+
+    // Get all question types available on system.
+    $qtypes = mod_studentquiz_get_question_types();
+    // Replace all value to 1 for default value without foreach loop.
+    $defaultqtypes = array_map(function($val) {
+        return 1;
+    }, $qtypes);
+
+    $settings->add(new admin_setting_configmulticheckbox('studentquiz/defaultqtypes',
+            get_string('settings_qtypes_default_new_activity', 'studentquiz'),
+            '',
+            $defaultqtypes,
+            $qtypes
+    ));
 
 }

--- a/tests/behat/admin_settings.feature
+++ b/tests/behat/admin_settings.feature
@@ -1,0 +1,43 @@
+@mod @mod_studentquiz
+Feature: New activities instances setting will be inherited from Admin setting
+  In order not to change the allowed question types every time it was created
+  As a teacher
+  I need a default allowed question types option Admin setting and new StudentQuiz will use it
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+
+  @javascript
+  Scenario: Check Default question types appear in Admin setting
+    Given I log in as "admin"
+    When I navigate to "Plugins > StudentQuiz" in site administration
+    Then I should see "Default question types"
+    And I should see "The following are default for a new activity"
+    And the field "s_studentquiz_defaultqtypes[multichoice]" matches value "1"
+    And the field "s_studentquiz_defaultqtypes[truefalse]" matches value "1"
+    And the field "s_studentquiz_defaultqtypes[shortanswer]" matches value "1"
+
+  @javascript
+  Scenario: Check new instance will get the default question types from Admin setting
+    Given I log in as "admin"
+    And the following config values are set as admin:
+      | defaultqtypes | truefalse | studentquiz |
+    And I am on "Course 1" course homepage
+    And I turn editing mode on
+    And I add a "StudentQuiz" to section "1"
+    When I expand all fieldsets
+    Then the field "allowedqtypes[truefalse]" matches value "1"
+    And the field "allowedqtypes[ALL]" matches value "0"
+    And the field "allowedqtypes[multichoice]" matches value "0"
+    And the field "allowedqtypes[shortanswer]" matches value "0"
+    And I press "Cancel"
+    And the following config values are set as admin:
+      | defaultqtypes | truefalse,multichoice | studentquiz |
+    And I add a "StudentQuiz" to section "1"
+    And I expand all fieldsets
+    And the field "allowedqtypes[truefalse]" matches value "1"
+    And the field "allowedqtypes[multichoice]" matches value "1"
+    And the field "allowedqtypes[ALL]" matches value "0"
+    And the field "allowedqtypes[shortanswer]" matches value "0"


### PR DESCRIPTION
Hi Frank,
We have an enhancement for StudentQuiz as below:

-----------------------------------
We are likely to recommend only specific ‘simple’ question types are used in Student Quiz activities
Currently, each time a new activity is set up, it defaults to all questions types.
We would prefer that the server settings for the Student Quiz plugin (/admin/settings.php?section=modsettingstudentquiz) allowed administrators to set the defaults.

Currently, there is a hidden setting that defaults to “Allow all question types”.
So an alternative option should be available to set specific defaults, as shown in Figure 1.

If specific question types are selected, they should be inherited every time a new Student Quiz activity is created on the server.

Note that those creating the activity are still free to change the ‘Allowed question types’.

![image](https://user-images.githubusercontent.com/11548406/49135241-ba96a680-f318-11e8-82ee-be971ec92752.png)
Figure 1: New “Default question types” setting in the plugin-in settings, with the alternative ‘Specific question types’ selected.

In the Student Quiz activity settings on a website, the plug-in defaults should be inherited. So if Figure 1 was set and a new Student Quiz activity created, question types would be pre-populated as shown in Figure 2.

![image](https://user-images.githubusercontent.com/11548406/49135275-d4d08480-f318-11e8-9a7e-46fd89ae7ed4.png)
Figure 2 If specific questions are set in the plug-in settings, they are inherited every time a new Student Quiz activity is created.

-----------------------------------

Thanks,
Huong Nguyen