### PR TITLE
Enhancement: Ranking to include ‘Anonymised’ in block title if activity is anonymised

### DIFF
--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -95,6 +95,7 @@ $string['no_questions_add'] = 'There are no questions in this StudentQuiz. Feel 
 // Blocks.
 $string['statistic_block_title'] = 'My Progress';
 $string['ranking_block_title'] = 'Ranking';
+$string['ranking_block_title_anonymised'] = 'Ranking (anonymised)';
 $string['statistic_block_progress_never'] = 'Questions never answered';
 $string['statistic_block_progress_last_attempt_correct'] = 'Latest attempt correct';
 $string['statistic_block_progress_last_attempt_incorrect'] = 'Latest attempt wrong';

--- a/renderer.php
+++ b/renderer.php
@@ -125,6 +125,11 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         $anonymname = get_string('creator_anonym_firstname', 'studentquiz') . ' '
                         . get_string('creator_anonym_lastname', 'studentquiz');
         $anonymise = $report->is_anonymized();
+        $studentquiz = mod_studentquiz_load_studentquiz($report->get_cm_id(), $this->page->context->id);
+        // We need to check this instead of using $report->is_anonymized()
+        // because we want to apply this text regardless of role.
+        $blocktitle = $studentquiz->anonymrank ? get_string('ranking_block_title_anonymised', 'studentquiz') :
+                get_string('ranking_block_title', 'studentquiz');
         $rows = array();
         $rank = 1;
         foreach ($ranking as $row) {
@@ -146,7 +151,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         $bc->attributes['id'] = 'mod_studentquiz_rankingblock';
         $bc->attributes['role'] = 'navigation';
         $bc->attributes['aria-labelledby'] = 'mod_studentquiz_navblock_title';
-        $bc->title = html_writer::span(get_string('ranking_block_title', 'studentquiz'));
+        $bc->title = html_writer::span($blocktitle);
         $bc->content = implode('', $rows);
         return $bc;
     }

--- a/tests/behat/anonymised_instance.feature
+++ b/tests/behat/anonymised_instance.feature
@@ -1,0 +1,37 @@
+@mod @mod_studentquiz
+Feature: StudentQuiz anonymous mode
+  In order for clear to user
+  As a user
+  I want to see (anonymised) in Ranking block when StudentQuiz is a anonymous instance.
+
+  Background:
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | student1 | Sam1      | Student1 | student1@example.com |
+      | student2 | Sam2      | Student2 | student2@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | C1     | student |
+      | student2 | C1     | student |
+
+  Scenario: Student should not see anonymised when StudentQuiz is a non-anonymous instance
+    Given the following "activities" exist:
+      | activity    | name          | intro              | course | idnumber     | anonymrank |
+      | studentquiz | StudentQuiz 1 | Quiz 1 description | C1     | studentquiz1 | 0          |
+    And I log in as "student1"
+    And I am on "Course 1" course homepage
+    When I follow "StudentQuiz 1"
+    Then I should see "Ranking" in the "#mod_studentquiz_rankingblock" "css_element"
+    And I should not see "Ranking (anonymised)" in the "#mod_studentquiz_rankingblock" "css_element"
+
+  Scenario: Student should see anonymised when StudentQuiz is a anonymous instance
+    Given the following "activities" exist:
+      | activity    | name          | intro              | course | idnumber     | anonymrank |
+      | studentquiz | StudentQuiz 1 | Quiz 1 description | C1     | studentquiz1 | 1          |
+    And I log in as "student1"
+    And I am on "Course 1" course homepage
+    When I follow "StudentQuiz 1"
+    Then I should see "Ranking (anonymised)" in the "#mod_studentquiz_rankingblock" "css_element"


### PR DESCRIPTION
Hi Frank,
We have an enhancement for StudentQuiz as below:

----------------------------
The thinking here was that we should be clear to users when the activity is or isn’t used in anonymous mode. In the future, a student might encounter a variety of anonymous and non—anonymous Student Quiz instances, and thus it should be communicated better.

Essentially IF anonymisation settings TRUE, change ‘Ranking’ title to “Ranking (anonymised)”.

This should show regardless of role, as it will remind all users of the activity as to its settings (even when moderators can see through the anonymisation setting).

So left would be what a student would see if activity is not anonymised, and how they would see it if anonymised. The only difference is that '(anonymised)' is added to the block title.
![image](https://user-images.githubusercontent.com/11548406/49418157-6b86c080-f7b3-11e8-9c83-3b3dbadb9c28.png)

----------------------------
Thanks,
Huong Nguyen