### PR TITLE
Enhancement: Add Ranking/Stats report to Ranking/Progress boxes

### DIFF
--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -54,6 +54,7 @@ $string['mydifficulty_column_name'] = 'My Difficulty';
 $string['difficulty_all_column_name'] = 'Community Difficulty';
 $string['mylastattempt_column_name'] = 'My Last Attempt';
 $string['myrate_column_name'] = 'My Rating';
+$string['more'] = 'More';
 $string['start_quiz_button'] = 'Start Quiz';
 $string['review_button'] = 'Review';
 $string['finish_button'] = 'Finish';

--- a/renderer.php
+++ b/renderer.php
@@ -68,6 +68,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         // TODO: Refactor: use mod_studentquiz_report_record_type!
         $userstats = $report->get_user_stats();
         $sqstats = $report->get_studentquiz_stats();
+        $cmid = $report->get_cm_id();
         if (!$userstats) {
             $bc = new block_contents();
             $bc->attributes['id'] = 'mod_studentquiz_statblock';
@@ -116,6 +117,12 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
             . html_writer::div(get_string('statistic_block_created', 'studentquiz')
                 .html_writer::span('<b>' .$userstats->questions_created .'</b>', '',
                     array('style' => 'float: right;')));
+
+        // Add More link to Stat block.
+        $reporturl = new moodle_url('/mod/studentquiz/reportstat.php', ['id' => $cmid]);
+        $readmorelink = $this->render_report_more_link($reporturl);
+        $bc->content .= $readmorelink;
+
         return $bc;
     }
 
@@ -125,6 +132,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         $anonymname = get_string('creator_anonym_firstname', 'studentquiz') . ' '
                         . get_string('creator_anonym_lastname', 'studentquiz');
         $anonymise = $report->is_anonymized();
+        $cmid = $report->get_cm_id();
         $rows = array();
         $rank = 1;
         foreach ($ranking as $row) {
@@ -148,6 +156,12 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         $bc->attributes['aria-labelledby'] = 'mod_studentquiz_navblock_title';
         $bc->title = html_writer::span(get_string('ranking_block_title', 'studentquiz'));
         $bc->content = implode('', $rows);
+
+        // Add More link to Ranking block.
+        $reporturl = new moodle_url('/mod/studentquiz/reportrank.php', ['id' => $cmid]);
+        $readmorelink = $this->render_report_more_link($reporturl);
+        $bc->content .= $readmorelink;
+
         return $bc;
     }
 
@@ -770,6 +784,20 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
                         'tip' => get_string('mine_column_name', 'studentquiz')
                 ]
         ];
+    }
+
+    /**
+     * Get report read more link.
+     *
+     * @param moodle_url $url Url to the report.
+     * @return string Html string of read more link.
+     */
+    public function render_report_more_link($url) {
+        $output = html_writer::start_div('report_more_url');
+        $output .= html_writer::link($url, get_string('more', 'studentquiz'));
+        $output .= html_writer::end_div();
+
+        return $output;
     }
 
 }

--- a/styles.css
+++ b/styles.css
@@ -314,3 +314,8 @@ body.page-mod-studentquiz-reportquiz table tbody tr.gradedattempt > td {
 #page-mod-studentquiz-view .modulespecificbuttonscontainer input.btn {
     margin-right: 5px;
 }
+
+#page-mod-studentquiz-view #mod_studentquiz_statblock .report_more_url,
+#page-mod-studentquiz-view #mod_studentquiz_rankingblock .report_more_url {
+    text-align: right;
+}

--- a/tests/behat/navigation.feature
+++ b/tests/behat/navigation.feature
@@ -56,3 +56,13 @@ Feature: Navigation to the pages
     Then I should see "Import"
     Then I should see "Export"
     Then I should see "Select a category:"
+
+  Scenario: Check that the More link exist in My Progress and Ranking block
+    When I navigate to "StudentQuiz" in current page administration
+    Then "More" "link" should exist in the "#mod_studentquiz_statblock" "css_element"
+    And I click on "More" "link" in the "#mod_studentquiz_statblock" "css_element"
+    And I should see "Statistics"
+    And I follow "StudentQuiz 1"
+    And "More" "link" should exist in the "#mod_studentquiz_rankingblock" "css_element"
+    And I click on "More" "link" in the "#mod_studentquiz_rankingblock" "css_element"
+    And I should see "Ranking"


### PR DESCRIPTION
Hi Frank,
We have an enhancement for StudentQuiz as below:

--------------------------
![image](https://user-images.githubusercontent.com/11548406/49418357-59595200-f7b4-11e8-84cb-ecb0e908ed51.png)
**Figure 1 Admin block (staff view)**
Students do not have access to the Administration block at the OU, and therefore do not have signposted access to their reports (although they can access them if given the URL)

'More' is the usual link I've seen in Moodle, see Figure 2. 

A simple solution would be to add a second copy of the link to the bottom of the 'My progress' and 'Ranking' block. It makes more sense to be there. (Note: we are not removing the existing links from the Administration block, merely creating a secondary way to view them).

![image 1](https://user-images.githubusercontent.com/11548406/49418381-68d89b00-f7b4-11e8-910b-77dc0f80413f.png)
**Figure 2: mockup of new links**

--------------------------

Thanks,
Huong Nguyen