### PR TITLE
removal of usage of global variables

### DIFF
--- a/classes/condition/studentquiz_condition.php
+++ b/classes/condition/studentquiz_condition.php
@@ -81,9 +81,7 @@ class studentquiz_condition extends \core_question\bank\search\condition {
         return $this->istagfilteractive;
     }
 
-
     protected function init() {
-
         if ($adddata = $this->filterform->get_data()) {
 
             $this->tests = array();

--- a/classes/question/bank/question_bank_filter.php
+++ b/classes/question/bank/question_bank_filter.php
@@ -102,30 +102,6 @@ class mod_studentquiz_question_bank_filter_form extends moodleform {
         $mform->setType('cmid', PARAM_RAW);
     }
 
-    /**
-     * Set form defaults
-     */
-    public function set_defaults() {
-        $submission = array();
-        foreach ($this->fields as $field) {
-            if (isset($_POST[$field->_name])) {
-                $submission[$field->_name] = $_POST[$field->_name];
-            }
-            if (isset($_POST[$field->_name . '_op'])) {
-                $submission[$field->_name . '_op'] = $_POST[$field->_name . '_op'];
-            }
-        }
-        if (isset($_POST['timecreated_sdt'])) {
-            $submission['timecreated_sdt'] = $_POST['timecreated_sdt'];
-        }
-        if (isset($_POST['timecreated_edt'])) {
-            $submission['timecreated_edt'] = $_POST['timecreated_edt'];
-        }
-        if (isset($_POST['createdby'])) {
-            $submission['createdby'] = $_POST['createdby'];
-        }
-        $this->_form->updateSubmission($submission, array());
-    }
 }
 
 class toggle_filter_checkbox extends user_filter_checkbox {

--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -682,7 +682,7 @@ class studentquiz_bank_view extends \core_question\bank\view {
      * Load question from database
      * @param int $page
      * @param int $perpage
-     * @return pqginated array of questions
+     * @return paginated array of questions
      */
     private function load_questions($page, $perpage) {
         global $DB;

--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -664,111 +664,18 @@ class studentquiz_bank_view extends \core_question\bank\view {
      */
     private function initialize_filter_form($pageurl) {
         $this->isfilteractive = false;
-        $this->set_filter_post_data();
 
-        $reset = optional_param('resetbutton', false, PARAM_ALPHA);
-        if ($reset) {
-            $this->reset_filter();
+        // If reset button was pressed, redirect the user again to the page.
+        // This means all submitted data is intentionally lost and thus the form clean again.
+        if (optional_param('resetbutton', false, PARAM_ALPHA)) {
+            redirect($pageurl);
         }
 
-        $createdby = optional_param('createdby', false, PARAM_INT);
-        if ($createdby) {
-            $this->set_createdby_user_id();
-        }
-
-        $this->modify_base_url();
         $this->filterform = new \mod_studentquiz_question_bank_filter_form(
             $this->fields,
             $pageurl->out(),
             array('cmid' => $this->cm->id)
         );
-        $this->filterform->set_defaults();
-    }
-
-    /**
-     * Set data for filter recognition
-     */
-    private function set_filter_post_data() {
-        foreach ($this->fields as $field) {
-            if (isset($_GET[$field->_name])) {
-                $_POST[$field->_name] = $_GET[$field->_name];
-            }
-
-            if (isset($_GET[$field->_name . '_op'])) {
-                $_POST[$field->_name . '_op'] = $_GET[$field->_name . '_op'];
-            }
-        }
-
-        if (isset($_POST['timecreated_sdt'])) {
-            $_POST['timecreated_sdt']['enabled'] = '1';
-            $_POST['timecreated_sdt']['day'] = $_GET['timecreated_sdt_day'];
-            $_POST['timecreated_sdt']['month'] = $_GET['timecreated_sdt_month'];
-            $_POST['timecreated_sdt']['year'] = $_GET['timecreated_sdt_year'];
-        }
-
-        if (isset($_POST['timecreated_edt'])) {
-            $_POST['timecreated_edt']['enabled'] = '1';
-            $_POST['timecreated_edt']['day'] = $_GET['timecreated_edt_day'];
-            $_POST['timecreated_edt']['month'] = $_GET['timecreated_edt_month'];
-            $_POST['timecreated_edt']['year'] = $_GET['timecreated_edt_year'];
-        }
-
-        if (isset($_GET['createdby'])) {
-            $_POST['createdby'] = '1';
-        }
-    }
-
-    /**
-     * Reset the filter
-     */
-    private function reset_filter() {
-        foreach ($this->fields as $field) {
-            $_POST[$field->_name] = '';
-            $_POST[$field->_name . '_op'] = '0';
-        }
-
-        unset($_POST['timecreated_sdt']);
-        unset($_POST['timecreated_edt']);
-        unset($_POST['createdby']);
-    }
-
-    /**
-     * Set createby POST data
-     */
-    private function set_createdby_user_id() {
-        global $USER;
-        $_POST['createdby'] = $USER->id;
-    }
-
-    /**
-     * Modify base url for ordering
-     */
-    private function modify_base_url() {
-        foreach ($this->fields as $field) {
-            if (isset($_POST[$field->_name])) {
-                $this->baseurl->param($field->_name, $_POST[$field->_name]);
-            }
-
-            if (isset($_POST[$field->_name . '_op'])) {
-                $this->baseurl->param($field->_name . '_op', $_POST[$field->_name . '_op']);
-            }
-        }
-
-        if (isset($_POST['timecreated_sdt'])) {
-            $this->baseurl->param('timecreated_sdt_day', $_POST['timecreated_sdt']['day']);
-            $this->baseurl->param('timecreated_sdt_month', $_POST['timecreated_sdt']['month']);
-            $this->baseurl->param('timecreated_sdt_year', $_POST['timecreated_sdt']['year']);
-        }
-
-        if (isset($_POST['timecreated_edt'])) {
-            $this->baseurl->param('timecreated_edt_day', $_POST['timecreated_edt']['day']);
-            $this->baseurl->param('timecreated_edt_month', $_POST['timecreated_edt']['month']);
-            $this->baseurl->param('timecreated_edt_year', $_POST['timecreated_edt']['year']);
-        }
-
-        if (isset($_POST['createdby'])) {
-            $this->baseurl->param('createdby', $_POST['createdby']);
-        }
     }
 
     /**

--- a/locallib.php
+++ b/locallib.php
@@ -951,8 +951,6 @@ function mod_studentquiz_get_question_types_keys() {
     return array_keys($types);
 }
 
-
-
 /**
  * Add capabilities to teacher (Non editing teacher) and
  * Student roles in the context of this context

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,13 +14,14 @@
         stopOnIncomplete="false"
         stopOnSkipped="false"
         beStrictAboutTestsThatDoNotTestAnything="false"
+        beStrictAboutOutputDuringTests="true"
         printerClass="Hint_ResultPrinter"
         testSuiteLoaderClass="phpunit_autoloader"
         >
 
     <php>
         <!--<const name="PHPUNIT_LONGTEST" value="1"/> uncomment to execute also slow or otherwise expensive tests-->
-        <const name="PHPUNIT_SEQUENCE_START" value="196000"/>
+        <const name="PHPUNIT_SEQUENCE_START" value="119000"/>
 
         <!--Following constants instruct tests to fetch external test files from alternative location or skip tests if empty, clone https://github.com/moodlehq/moodle-exttests to local web server-->
         <!--<const name="TEST_EXTERNAL_FILES_HTTP_URL" value="http://download.moodle.org/unittest"/> uncomment and alter to fetch external test files from alternative location-->

--- a/tests/studentquiz_bank_view_test.php
+++ b/tests/studentquiz_bank_view_test.php
@@ -226,13 +226,9 @@ class mod_studentquiz_bank_view_test extends advanced_testcase {
      */
     protected function displayqb($questionbank, $qpage = 0, $qperpage = 20, $recurse = 1, $showhidden = 0, $qbshowtext = 0) {
         $cat = $this->cat->id . "," . $this->ctx->id;
-        ob_start();
         $questionbank->display('questions', $qpage, $qperpage,
             $cat, $recurse, $showhidden,
             $qbshowtext);
-        $output = ob_get_contents();
-        ob_end_clean();
-        return $output;
     }
 
     /**
@@ -243,5 +239,8 @@ class mod_studentquiz_bank_view_test extends advanced_testcase {
     protected function set_filter($which, $value) {
         $_POST[$which] = $value;
         $_POST["submitbutton"] = "Filter";
+        // session key is required, otherwise it won't try to load and filter POSTed data
+        $_POST["_qf__mod_studentquiz_question_bank_filter_form"] = "1";
+        $_POST["sesskey"] = sesskey();
     }
 }

--- a/tests/viewlib_test.php
+++ b/tests/viewlib_test.php
@@ -59,6 +59,9 @@ class mod_studentquiz_viewlib_testcase extends advanced_testcase {
             , array('course' => $course->id),  array('anonymrank' => true));
 
         $this->cm = get_coursemodule_from_id('studentquiz', $studentquiz->cmid);
+        // Some internal moodle functions (e.g. question_edit_setup()) require the cmid to be found in $_xxx['cmid'].
+        $_GET['cmid'] = $this->cm->id;
+
         // Satisfy codechecker: $course $context $cm $studentquiz $userid.
         $context = context_module::instance($this->cm->id);
         $report = new mod_studentquiz_report($this->cm->id);

--- a/view.php
+++ b/view.php
@@ -33,6 +33,9 @@ require_once(__DIR__.'/reportlib.php');
 // Get parameters.
 if (!$cmid = optional_param('cmid', 0, PARAM_INT)) {
     $cmid = required_param('id', PARAM_INT);
+    // Some internal moodle functions (e.g. question_edit_setup()) require the cmid to be found in $_xxx['cmid'],
+    // but moodle allows to view a mod page with parameter id in place of cmid.
+    $_GET['cmid'] = $cmid;
 }
 
 // Load course and course module requested.

--- a/viewlib.php
+++ b/viewlib.php
@@ -124,29 +124,23 @@ class mod_studentquiz_view {
      * Loads the question custom bank view
      */
     private function load_questionbank() {
-
-        // Workaround to get permission to use questionbank.
-        // TODO: Refactor!
-        $_GET['cmid'] = $this->get_cm_id();
-        $_POST['cat'] = $this->get_category_id() . ',' . $this->get_context_id();
-
-        // Hide question text.
-        // TODO: Refactor!
-        $_GET["qbshowtext"] = 0;
-
         // Ensure capabilities are set to load question bank.
         // When there are changes to the required capabilities for different moodles, the capabilities have to be corrected
         // TODO: We should fix these with the updates and restore functions (analog fix question category etc.)
         mod_studentquiz_ensure_question_capabilities($this->context);
 
-        // TODO: This is the problematic redirect call for unittests!
+        // Get edit question link setup
         list($thispageurl, $contexts, $cmid, $cm, $module, $pagevars)
             = question_edit_setup('questions', '/mod/studentquiz/view.php', true);
         $pagevars['qperpage'] = optional_param('qperpage', DEFAULT_QUESTIONS_PER_PAGE, PARAM_INT);
         $pagevars['showall'] = optional_param('showall', false, PARAM_BOOL);
+        $pagevars['cat'] = $this->get_category_id() . ',' . $this->get_context_id();
 
         $this->pageurl = new moodle_url($thispageurl);
 
+        // Trigger notification if user got returned from the question edit form.
+        // TODO: Shouldn't this be somewhere outside of load_questionbank(), as this is clearly not relevant for showing the
+        // question bank?
         if (($lastchanged = optional_param('lastchanged', 0, PARAM_INT)) !== 0) {
             $this->pageurl->param('lastchanged', $lastchanged);
             // Ensure we have a studentquiz_question record.


### PR DESCRIPTION
From [MDL-62822](https://tracker.moodle.org/browse/MDL-62822?focusedCommentId=647722&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-647722)

> classes/question/bank/question_bank_filter.php
> Any reason for using $_POST variables directly on set_defaults()? This is not recommended at all.

> classes/question/bank/studentquiz_bank_view.php
> Another usages of $_GET and $_POST directly, pretty sure this will require some refactoring.

- removed all usage of $_ params where needed
- during the process detected, that most affected code is not necessary at all, so removed
- category is found by default category of the current context
- From the view.php: if cmid is passed via 'id', 'cmid' is getting set - this place is probably best for that need

This PR needs most likely also a good manual test of the filter! Please have a look into that too.