### PR TITLE
fixed import coding style and use html_writer whenever html tags need to be written

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -22,9 +22,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
+require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/questionlib.php');
-require_once(dirname(__FILE__) . '/locallib.php');
+require_once(__DIR__ . '/locallib.php');
 
 // Get parameters.
 $cmid = required_param('cmid', PARAM_INT);
@@ -217,7 +217,7 @@ $html .= html_writer::tag('h2', $title);
 $html .= html_writer::start_tag('form', array('method' => 'post', 'action' => $actionurl,
     'enctype' => 'multipart/form-data', 'id' => 'responseform'));
 
-$html .= '<input type="hidden" class="cmid_field" name="cmid" value="' . $cmid . '" />';
+$html .= html_writer::empty_tag('input', array('type' => 'hidden', 'name' => 'cmid', 'value' => $cmid, 'class' => 'cmid_field'));
 
 // Output the question.
 $html .= $questionusage->render_question($slot, $options, (string)$slot);

--- a/classes/question/bank/question_bank_filter.php
+++ b/classes/question/bank/question_bank_filter.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/lib/formslib.php');
-require_once($CFG->dirroot.'/user/filters/text.php');
-require_once($CFG->dirroot.'/user/filters/date.php');
+require_once($CFG->dirroot . '/lib/formslib.php');
+require_once($CFG->dirroot . '/user/filters/text.php');
+require_once($CFG->dirroot . '/user/filters/date.php');
 
 /**
  * Question bank filter form intance

--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -349,7 +349,7 @@ class studentquiz_bank_view extends \core_question\bank\view {
             if (optional_param('deleteselected', false, PARAM_BOOL)) {
                 // Add an explanation about questions in use.
                 if ($inuse) {
-                    $questionnames .= '<br />'.get_string('questionsinuse', 'question');
+                    $questionnames .= \html_writer::empty_tag('br').get_string('questionsinuse', 'question');
                 }
 
                 $deleteurl = new \moodle_url($baseurl, array('deleteselected' => $questionlist, 'confirm' => md5($questionlist),
@@ -361,7 +361,7 @@ class studentquiz_bank_view extends \core_question\bank\view {
             } else if (optional_param('approveselected', false, PARAM_BOOL)) {
                 // Add an explanation about questions in use.
                 if ($inuse) {
-                    $questionnames .= '<br />'.get_string('questionsinuse', 'studentquiz');
+                    $questionnames .= \html_writer::empty_tag('br').get_string('questionsinuse', 'studentquiz');
                 }
 
                 $approveurl = new \moodle_url($baseurl, array('approveselected' => $questionlist, 'confirm' => md5($questionlist),
@@ -549,7 +549,7 @@ class studentquiz_bank_view extends \core_question\bank\view {
 
     protected function display_question_list_rows() {
         $output = '';
-        $output .= '<div class="categoryquestionscontainer">';
+        $output .= \html_writer::start_div('categoryquestionscontainer');
         ob_start();
         $this->start_table();
         $rowcount = 0;
@@ -561,7 +561,7 @@ class studentquiz_bank_view extends \core_question\bank\view {
         $this->end_table();
         $output .= ob_get_contents();
         ob_end_clean();
-        $output .= "</div>\n";
+        $output .= \html_writer::end_div();
         return $output;
     }
 

--- a/db/uninstall.php
+++ b/db/uninstall.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/course/lib.php');
+require_once($CFG->dirroot . '/course/lib.php');
 require_once(__DIR__ . '/../lib.php');
 
 /**

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -31,7 +31,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once(dirname(__DIR__) . '/locallib.php');
+require_once(__DIR__ . '/../locallib.php');
 
 /**
  * Execute StudentQuiz upgrade from the given old version
@@ -321,7 +321,7 @@ function xmldb_studentquiz_upgrade($oldversion) {
     // Update capabilities list and permission types, to make sure the defaults are set after this upgrade.
     if ($oldversion < 2017112602) {
         // Load current access definition for easier iteration.
-        require_once(dirname(__DIR__) . '/db/access.php');
+        require_once(__DIR__ . '/../db/access.php');
         // Load all contexts this has to be defined.
         // Only system context needed, as by default it's inherited from there.
         // if someone did make an override, it's intentional.

--- a/index.php
+++ b/index.php
@@ -22,8 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(__DIR__)).'/config.php');
-require_once(__DIR__ .'/lib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
 
 $id = required_param('id', PARAM_INT);
 if (!$course = $DB->get_record('course', array('id' => $id))) {
@@ -95,10 +95,10 @@ foreach ($studentquizzes as $studentquiz) {
     // Link to the instance.
     $class = '';
     if (!$studentquiz->visible) {
-        $class = ' class="dimmed"';
+        $class = 'dimmed';
     }
-    $data[] = "<a$class href=\"view.php?id=$studentquiz->coursemodule\">" .
-        format_string($studentquiz->name, true) . '</a>';
+    $data[] = html_writer::tag('a', format_string($studentquiz->name, true), array(
+        'href' => "view.php?id=" . $studentquiz->coursemodule, 'class' => $class));
 
     $table->data[] = $data;
 } // End of loop over studentquiz instances.

--- a/migrate.php
+++ b/migrate.php
@@ -23,7 +23,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(__DIR__)).'/config.php');
+require_once(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/viewlib.php');
 require_once(__DIR__ . '/renderer.php');
 

--- a/preview.php
+++ b/preview.php
@@ -120,7 +120,7 @@ echo $OUTPUT->header();
 if ($question) {
     echo html_writer::start_tag('form', array('method' => 'post', 'action' => $actionurl,
         'enctype' => 'multipart/form-data', 'id' => 'responseform'));
-    echo '<input type="hidden" class="cmid_field" name="cmid" value="' . $cmid . '" />';
+    echo html_writer::empty_tag('input', array('type' => 'hidden', 'name' => 'cmid', 'value' => $cmid, 'class' => 'cmid_field'));
 
     echo $quba->render_question($slot, $options, 'i');
 

--- a/questionbank.ajax.php
+++ b/questionbank.ajax.php
@@ -24,7 +24,7 @@
 
 define('AJAX_SCRIPT', true);
 
-require_once(dirname(dirname(__DIR__)).'/config.php');
+require_once(__DIR__ . '/../../config.php');
 require_once($CFG->dirroot . '/mod/quiz/locallib.php');
 require_once($CFG->dirroot . '/question/editlib.php');
 

--- a/renderer.php
+++ b/renderer.php
@@ -261,9 +261,9 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         $percentone = round(100 * ($info->one / $info->total));
 
         if (!empty($texttotal)) {
-            $text = '<text xml:space="preserve" text-anchor="start" font-family="Helvetica, Arial, sans-serif"'
-             .' font-size="12" font-weight="bold" id="svg_text" x="50%" y="50%" alignment-baseline="middle"'
-             .' text-anchor="middle" stroke-width="0" stroke="#000" fill="#000000">' . $texttotal . '</text>';
+            $text = html_writer::tag('text', $texttotal, array('xml:space' => 'preserve', 'text-anchor' => 'start', 'font-family' => 'Helvetica, Arial, sans-serif',
+            'font-size' => '12', 'font-weight' => 'bold', 'id' => 'svg_text', 'x' => '50%', 'y' => '50%', 'alignment-baseline' => 'middle', 'text-anchor' => 'middle',
+            'stroke-width' => '0', 'stroke' => '#000', 'fill' => '#000'));
         } else {
             $text = '';
         }

--- a/reportrank.php
+++ b/reportrank.php
@@ -22,9 +22,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(__DIR__)).'/config.php');
-require_once(__DIR__.'/reportlib.php');
-require_once(__DIR__.'/classes/event/studentquiz_report_rank_viewed.php');
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/reportlib.php');
+require_once(__DIR__ . '/classes/event/studentquiz_report_rank_viewed.php');
 
 $cmid = optional_param('id', 0, PARAM_INT);
 if (!$cmid) {

--- a/reportstat.php
+++ b/reportstat.php
@@ -22,9 +22,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(__DIR__)).'/config.php');
-require_once(__DIR__.'/reportlib.php');
-require_once(__DIR__.'/classes/event/studentquiz_report_quiz_viewed.php');
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/reportlib.php');
+require_once(__DIR__ . '/classes/event/studentquiz_report_quiz_viewed.php');
 
 $cmid = optional_param('id', 0, PARAM_INT);
 if (!$cmid) {

--- a/view.php
+++ b/view.php
@@ -25,10 +25,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(__DIR__)).'/config.php');
+require_once(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/viewlib.php');
-require_once(__DIR__.'/classes/event/studentquiz_questionbank_viewed.php');
-require_once(__DIR__.'/reportlib.php');
+require_once(__DIR__ . '/classes/event/studentquiz_questionbank_viewed.php');
+require_once(__DIR__ . '/reportlib.php');
 
 // Get parameters.
 if (!$cmid = optional_param('cmid', 0, PARAM_INT)) {


### PR DESCRIPTION
From [MDL-62822](https://tracker.moodle.org/browse/MDL-62822?focusedCommentId=647722&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-647722)

> **attempt.php**
> 1. Any reason for including config.php this way?
>   - My suggestion is to replace that and other occurrences by:
> `require_once(__DIR__ . '/../../config.php');`
> 2. Usually we avoid this can we replace that to use html_writter instead?
