### PR TITLE
Trigger events after output has been sent

### DIFF
--- a/index.php
+++ b/index.php
@@ -32,12 +32,6 @@ if (!$course = $DB->get_record('course', array('id' => $id))) {
 $coursecontext = context_course::instance($id);
 require_login($course);
 
-$params = array(
-    'context' => $coursecontext
-);
-$event = \mod_studentquiz\event\course_module_instance_list_viewed::create($params);
-$event->trigger();
-
 $strname = get_string('modulenameplural', 'mod_studentquiz');
 $PAGE->set_url('/mod/studentquiz/index.php', array('id' => $id));
 $PAGE->navbar->add($strname);
@@ -108,3 +102,6 @@ echo html_writer::table($table);
 
 // Finish the page.
 echo $OUTPUT->footer();
+
+// Trigger instance list viewed event.
+mod_studentquiz_instancelist_viewed($coursecontext);

--- a/locallib.php
+++ b/locallib.php
@@ -493,7 +493,7 @@ function mod_studentquiz_add_question_to_attempt(&$questionusage, $studentquiz, 
 
 
 /**
- * Trigger Report viewed Event
+ * Trigger report viewed event.
  */
 function mod_studentquiz_report_viewed($cmid, $context) {
     // TODO: How about $cmid from $context?
@@ -507,7 +507,7 @@ function mod_studentquiz_report_viewed($cmid, $context) {
 }
 
 /**
- * Trigger Completion api and view Event
+ * Trigger completion api and view event.
  *
  * @param  stdClass $course     course object
  * @param  stdClass $cm         course module object
@@ -526,6 +526,37 @@ function mod_studentquiz_overview_viewed($course, $cm, $context) {
     // Completion.
     $completion = new completion_info($course);
     $completion->set_module_viewed($cm);
+}
+
+/**
+ * Trigger instance list viewed event.
+ *
+ * @param  stdClass $context    context object
+ */
+function mod_studentquiz_instancelist_viewed($context) {
+
+    $params = array(
+        'context' => $context
+    );
+
+    $event = \mod_studentquiz\event\course_module_instance_list_viewed::create($params);
+    $event->trigger();
+}
+
+/**
+ * Trigger report rank viewed event.
+ *
+ * @param  stdClass $context    context object
+ */
+function mod_studentquiz_reportrank_viewed($cmid, $context) {
+
+    $params = array(
+        'objectid' => $cmid,
+        'context' => $context
+    );
+
+    $event = \mod_studentquiz\event\studentquiz_report_rank_viewed::create($params);
+    $event->trigger();
 }
 
 /**

--- a/locallib.php
+++ b/locallib.php
@@ -491,9 +491,50 @@ function mod_studentquiz_add_question_to_attempt(&$questionusage, $studentquiz, 
     question_engine::save_questions_usage_by_activity($questionusage);
 }
 
+/**
+ * Trigger completion.
+ *
+ * @param  stdClass $course     course object
+ * @param  stdClass $cm         course module object
+ */
+function mod_studentquiz_completion($course, $cm) {
+    $completion = new completion_info($course);
+    $completion->set_module_viewed($cm);
+}
+
+/**
+ * Trigger overview viewed event.
+ *
+ * @param int      $cmid       course module id
+ * @param stdClass $context    context object
+ */
+function mod_studentquiz_overview_viewed($cmid, $context) {
+    $params = array(
+        'objectid' => $cmid,
+        'context' => $context
+    );
+    $event = \mod_studentquiz\event\course_module_viewed::create($params);
+    $event->trigger();
+}
+
+/**
+ * Trigger instance list viewed event.
+ *
+ * @param stdClass $context    context object
+ */
+function mod_studentquiz_instancelist_viewed($context) {
+    $params = array(
+        'context' => $context
+    );
+    $event = \mod_studentquiz\event\course_module_instance_list_viewed::create($params);
+    $event->trigger();
+}
 
 /**
  * Trigger report viewed event.
+ *
+ * @param int      $cmid       course module id
+ * @param stdClass $context    context object
  */
 function mod_studentquiz_report_viewed($cmid, $context) {
     // TODO: How about $cmid from $context?
@@ -501,60 +542,21 @@ function mod_studentquiz_report_viewed($cmid, $context) {
         'objectid' => $cmid,
         'context' => $context
     );
-
     $event = \mod_studentquiz\event\studentquiz_report_quiz_viewed::create($params);
-    $event->trigger();
-}
-
-/**
- * Trigger completion api and view event.
- *
- * @param  stdClass $course     course object
- * @param  stdClass $cm         course module object
- * @param  stdClass $context    context object
- */
-function mod_studentquiz_overview_viewed($course, $cm, $context) {
-
-    $params = array(
-        'objectid' => $cm->id,
-        'context' => $context
-    );
-
-    $event = \mod_studentquiz\event\course_module_viewed::create($params);
-    $event->trigger();
-
-    // Completion.
-    $completion = new completion_info($course);
-    $completion->set_module_viewed($cm);
-}
-
-/**
- * Trigger instance list viewed event.
- *
- * @param  stdClass $context    context object
- */
-function mod_studentquiz_instancelist_viewed($context) {
-
-    $params = array(
-        'context' => $context
-    );
-
-    $event = \mod_studentquiz\event\course_module_instance_list_viewed::create($params);
     $event->trigger();
 }
 
 /**
  * Trigger report rank viewed event.
  *
- * @param  stdClass $context    context object
+ * @param stdClass $cmid       course module id
+ * @param stdClass $context    context object
  */
 function mod_studentquiz_reportrank_viewed($cmid, $context) {
-
     $params = array(
         'objectid' => $cmid,
         'context' => $context
     );
-
     $event = \mod_studentquiz\event\studentquiz_report_rank_viewed::create($params);
     $event->trigger();
 }

--- a/reportrank.php
+++ b/reportrank.php
@@ -24,7 +24,6 @@
 
 require_once(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/reportlib.php');
-require_once(__DIR__ . '/classes/event/studentquiz_report_rank_viewed.php');
 
 $cmid = optional_param('id', 0, PARAM_INT);
 if (!$cmid) {
@@ -33,13 +32,6 @@ if (!$cmid) {
 
 $report = new mod_studentquiz_report($cmid);
 require_login($report->get_course(), false, $report->get_coursemodule());
-
-$params = array(
-    'objectid' => $report->get_cm_id(),
-    'context' => $report->get_context()
-);
-$event = \mod_studentquiz\event\studentquiz_report_rank_viewed::create($params);
-$event->trigger();
 
 $PAGE->set_title($report->get_ranking_title());
 $PAGE->set_heading($report->get_heading());
@@ -53,3 +45,6 @@ echo $OUTPUT->header();
 echo $output->view_rank($report);
 
 echo $OUTPUT->footer();
+
+// Trigger report rank viewed event.
+mod_studentquiz_reportrank_viewed($report->get_cm_id(), $report->get_context());

--- a/reportstat.php
+++ b/reportstat.php
@@ -24,7 +24,6 @@
 
 require_once(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/reportlib.php');
-require_once(__DIR__ . '/classes/event/studentquiz_report_quiz_viewed.php');
 
 $cmid = optional_param('id', 0, PARAM_INT);
 if (!$cmid) {
@@ -36,8 +35,6 @@ $report = new mod_studentquiz_report($cmid);
 require_login($report->get_course(), false, $report->get_coursemodule());
 
 $context = context_module::instance($cmid);
-
-mod_studentquiz_report_viewed($cmid, $context);
 
 $PAGE->set_title($report->get_statistic_title());
 $PAGE->set_heading($report->get_heading());
@@ -51,3 +48,6 @@ $renderer = $PAGE->get_renderer('mod_studentquiz', 'report');
 echo $renderer->view_stat($report);
 
 echo $OUTPUT->footer();
+
+// Trigger report viewed event.
+mod_studentquiz_report_viewed($cmid, $context);

--- a/view.php
+++ b/view.php
@@ -27,7 +27,6 @@
 
 require_once(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/viewlib.php');
-require_once(__DIR__ . '/classes/event/studentquiz_questionbank_viewed.php');
 require_once(__DIR__ . '/reportlib.php');
 
 // Get parameters.
@@ -91,8 +90,6 @@ $PAGE->set_heading($COURSE->fullname);
 // Process actions.
 $view->process_actions();
 
-// Fire view event for completion API and event API.
-mod_studentquiz_overview_viewed($course, $cm, $context);
 
 $renderer->add_fake_block($report);
 
@@ -104,3 +101,5 @@ $PAGE->requires->js_init_code($renderer->render_bar_javascript_snippet(), true);
 
 echo $OUTPUT->footer();
 
+// Trigger completion api and view event.
+mod_studentquiz_overview_viewed($course, $cm, $context);

--- a/view.php
+++ b/view.php
@@ -90,6 +90,8 @@ $PAGE->set_heading($COURSE->fullname);
 // Process actions.
 $view->process_actions();
 
+// Trigger completion.
+mod_studentquiz_completion($course, $cm);
 
 $renderer->add_fake_block($report);
 
@@ -101,5 +103,5 @@ $PAGE->requires->js_init_code($renderer->render_bar_javascript_snippet(), true);
 
 echo $OUTPUT->footer();
 
-// Trigger completion api and view event.
-mod_studentquiz_overview_viewed($course, $cm, $context);
+// Trigger overview viewed event.
+mod_studentquiz_overview_viewed($cm->id, $context);


### PR DESCRIPTION
From [MDL-62822](https://tracker.moodle.org/browse/MDL-62822?focusedCommentId=647722&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-647722)

> index.php
Usually the event trigger should be placed AFTER the content is rendered, so this event trigger should be moved BELOW the line 107 in that file.
Same thing happens in other files, please place all event trigger calls after the content is actually rendered.
