### PR TITLE
moved functions used inline in ajax files into locallib

### DIFF
--- a/comment_list.php
+++ b/comment_list.php
@@ -51,5 +51,4 @@ if (mod_studentquiz_check_created_permission($cmid)) {
 
 $comments = mod_studentquiz_get_comments_with_creators($questionid);
 
-
 echo mod_studentquiz_comment_renderer($comments, $userid, $anonymize, $ismoderator);

--- a/remove.php
+++ b/remove.php
@@ -47,21 +47,6 @@ if ($cmid) {
 require_login($module->course, false, $module);
 require_sesskey();
 
-header('Content-Type: text/html; charset=utf-8');
+mod_studentquiz_delete_comment($commentid, $course, $module);
 
-$comment = $DB->get_record('studentquiz_comment', array('id' => $commentid));
-// TODO strange return 401?
-if (mod_studentquiz_check_created_permission($cmid)) {
-    // In this case an manager has deleted the comment.
-    mod_studentquiz_notify_comment_deleted($comment, $course, $module);
-    $success = $DB->delete_records('studentquiz_comment', array('id' => $commentid));
-    if (!$success) {
-        return http_response_code(401);
-    }
-} else {
-    // TODO: we could add here the same notification command, but it would here delete his own comment, just made in a strange way.
-    $success = $DB->delete_records('studentquiz_comment', array('id' => $commentid, 'userid' => $USER->id));
-    if (!$success) {
-        return http_response_code(401);
-    }
-}
+header('Content-Type: text/html; charset=utf-8');


### PR DESCRIPTION
From [MDL-62822](https://tracker.moodle.org/browse/MDL-62822?focusedCommentId=647722&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-647722)

> save.php
In my opinion these functions mod_studentquiz_save_rate() and mod_studentquiz_save_comment() should be moved to lib.php or locallib.php. The current placement doesn't seem right to me.

- also created a function (and moved the code to it) to remove a comment, honoring the present rules