### PR TITLE
Student Quiz: Inconsistent database defaults

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -488,5 +488,33 @@ function xmldb_studentquiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2019032002, 'studentquiz');
     }
 
+    // XMLDB "Check defaults" issues.
+    if ($oldversion < 2019051700) {
+
+        $table = new xmldb_table('studentquiz_progress');
+        
+        // Changing the default of field lastanswercorrect on table studentquiz_progress to drop it.
+        $field = new xmldb_field('lastanswercorrect', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, null, 'studentquizid');
+
+        // Launch change of default for field lastanswercorrect.
+        $dbman->change_field_default($table, $field);
+
+        // Changing the default of field attempts on table studentquiz_progress to drop it.
+        $field = new xmldb_field('attempts', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'lastanswercorrect');
+
+        // Launch change of default for field attempts.
+        $dbman->change_field_default($table, $field);
+
+        // Changing the default of field correctattempts on table studentquiz_progress to drop it.
+        $field = new xmldb_field('correctattempts', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'attempts');
+
+        // Launch change of default for field correctattempts.
+        $dbman->change_field_default($table, $field);
+        
+        // Studentquiz savepoint reached.
+        upgrade_mod_savepoint(true, 2019051700, 'studentquiz');
+    }
+
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'mod_studentquiz';
-$plugin->version      = 2019040100;
+$plugin->version      = 2019051700;
 $plugin->release      = 'v3.3.0';
 $plugin->requires     = 2017111306; // Version MOODLE_31, 3.4.0.
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
Hi Frank,
The XMLDB "Check defaults" tool was run via /admin/tool/xmldb/.
The following inconsistencies were found in mod_studentquiz:
Table: studentquiz_progress. Field: lastanswercorrect, Expected - Actual '0'
Table: studentquiz_progress. Field: attempts, Expected - Actual '0'
Table: studentquiz_progress. Field: correctattempts, Expected - Actual '0'

The upgarde.php has been modified to match install.xml.

Many thanks,
Mahmoud