### PR TITLE
StudentQuiz: Question-writing and Question-responding phase

### DIFF
--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -198,7 +198,11 @@ class studentquiz_bank_view extends \core_question\bank\view {
             );
             $output .= $this->renderer->render_question_form($questionslist);
         } else {
-            $output .= $this->renderer->render_no_questions_notification($this->isfilteractive);
+            list($message, $questionsubmissionallow) = mod_studentquiz_check_availability($this->studentquiz->opensubmissionfrom,
+                    $this->studentquiz->closesubmissionfrom, 'submission');
+            if ($questionsubmissionallow) {
+                $output .= $this->renderer->render_no_questions_notification($this->isfilteractive);
+            }
         }
         return $output;
     }


### PR DESCRIPTION
Hi Frank,
I have a small change as below:

If question-creating phase is yet to start, hide the green "There are no questions in this StudentQuiz. Feel free to add some questions" label
as you can't add any questions

![image](https://user-images.githubusercontent.com/11548406/58681340-245e3e80-8396-11e9-8039-395464b4f57e.png)

