### PR TITLE
StudentQuiz: 'Timing Information' banner needs a little padding along the bottom

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -289,3 +289,8 @@
     display: flex;
     justify-content: space-between;
 }
+
+.path-mod-studentquiz .mod_studentquiz_submission_info {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
Hi Frank, 
I have a small change as below:

As can be seen in the attached screenshots (Firefox, normal 100% zoom), there's no padding between the 'Timing information' banner and any other content, including the bottom of the StudentQuiz activity area.

We should add padding to the bottom of the same size as between the button and the top of the 'Timing information' banner as shown in screenshot 1 (attached)

![image](https://user-images.githubusercontent.com/11548406/58687015-98a2dd00-83aa-11e9-89a1-2ec5fb8828d9.png)
![image](https://user-images.githubusercontent.com/11548406/58687022-9ccefa80-83aa-11e9-9a81-3eb0f7010451.png)

Thanks,
Huong Nguyen