### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ cache:
 php:
  - 7.1
  - 7.2
- - 7.3
+ #- 7.3
 
 env:
   - MOODLE_BRANCH=MOODLE_35_STABLE DB=pgsql
@@ -46,15 +46,15 @@ matrix:
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
     - php: 7.2
       env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
+    #- php: 7.3
+    #  env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
     # Some MariaDB as backend with various PHP versions, but just some to save matrix slots
     - php: 7.1
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mariadb
     - php: 7.2
       env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mariadb
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mariadb
+    #- php: 7.3
+    #  env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mariadb
 
 before_install:
   # php settings
@@ -82,9 +82,9 @@ script:
   - moodle-plugin-ci codechecker
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
-  #- moodle-plugin-ci mustache #currently no mustache relevant files, so we can also omit the java packages above
+  #- moodle-plugin-ci mustache # currently no mustache relevant files, so we can also omit the java packages above
   - moodle-plugin-ci grunt
-  - moodle-plugin-ci phpdoc
+  #- moodle-plugin-ci phpdoc # should be enabled but the errors have to be fixed first
   - moodle-plugin-ci phpunit --coverage-text
-  - moodle-plugin-ci behat --profile chrome
+  #- moodle-plugin-ci behat --profile chrome # chromium is currently broken again...
   - moodle-plugin-ci behat # with firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ script:
   - moodle-plugin-ci savepoints
   #- moodle-plugin-ci mustache #currently no mustache relevant files, so we can also omit the java packages above
   - moodle-plugin-ci grunt
+  - moodle-plugin-ci phpdoc
   - moodle-plugin-ci phpunit --coverage-text
   - moodle-plugin-ci behat --profile chrome
   - moodle-plugin-ci behat # with firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ cache:
 php:
  - 7.1
  - 7.2
- #- 7.3 # https://github.com/blackboard-open-source/moodle-plugin-ci/issues/98
 
 env:
   - MOODLE_BRANCH=MOODLE_35_STABLE DB=pgsql
@@ -44,21 +43,22 @@ env:
 
 matrix:
   include:
+    # Only Moodle 37 and onwards has php 7.3 support
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=pgsql
     # Some MySQL as backend with various PHP versions, but just some to save matrix slots
     - php: 7.1
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
     - php: 7.2
       env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
-    #- php: 7.3 # see above
-    - php: 7.2
+    - php: 7.3
       env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
     # Some MariaDB as backend with various PHP versions, but just some to save matrix slots
     - php: 7.1
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mariadb
     - php: 7.2
       env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mariadb
-    #- php: 7.3 # see above
-    - php: 7.2
+    - php: 7.3
       env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mariadb
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: required
 notifications:
   email: false
 
+services:
+  - mysql
+
 addons:
   postgresql: "9.4"
   firefox: "47.0.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ cache:
 php:
  - 7.1
  - 7.2
- #- 7.3
+ #- 7.3 # https://github.com/blackboard-open-source/moodle-plugin-ci/issues/98
 
 env:
   - MOODLE_BRANCH=MOODLE_35_STABLE DB=pgsql
@@ -49,15 +49,17 @@ matrix:
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
     - php: 7.2
       env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
-    #- php: 7.3
-    #  env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
+    #- php: 7.3 # see above
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
     # Some MariaDB as backend with various PHP versions, but just some to save matrix slots
     - php: 7.1
       env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mariadb
     - php: 7.2
       env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mariadb
-    #- php: 7.3
-    #  env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mariadb
+    #- php: 7.3 # see above
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mariadb
 
 before_install:
   # php settings


### PR DESCRIPTION
- travis image has changed to xenial, fixes for that
- removed moodles and php versions which are out of support
- included jobs for mariadb as database backend
- added moodle 37
- added phpdoc test target, but disabled, as there are errors to fix
- disabled behat for chromium as not working right now