### PR TITLE
Provide a 'More help' link to MoodleDocs in activity chooser.

### DIFF
--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -181,6 +181,7 @@ $string['migrated_successful'] = 'This activity has been migrated successfully!'
 $string['mine_column_name'] = 'Mine';
 $string['modulename'] = 'StudentQuiz';
 $string['modulename_help'] = 'The StudentQuiz activity allows students to add questions for the crowd. In the StudentQuiz overview the students can filter questions. They also can use the filtered questions in the crowd to practice. The teacher has an option to anonymize the created by column.<br><br>The StudentQuiz activity awards the students with points to motivate them to add and practice. The Points are listed in a ranking table.<br><br>For more information read the <a href="https://studentquiz.hsr.ch/docs/">StudentQuiz documentation</a>.';
+$string['modulename_link'] = 'mod/studentquiz/view';
 $string['modulenameplural'] = 'StudentQuizzes';
 $string['more'] = 'More';
 $string['myattempts_column_name'] = 'My Attempts';


### PR DESCRIPTION
Thanks!
That would provide such a link:
<img width="357" alt="activitychooserdocslink" src="https://user-images.githubusercontent.com/377279/60031519-34bbbd80-96a5-11e9-807e-3f6118f92030.png">
