### PR TITLE
When Rating/Comment enforced, visual cue

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -224,7 +224,7 @@ $html .= $output->render_state_choice($question->id, $course->id, $cmid);
 
 // Output the rating.
 if ($hasanswered) {
-    $html .= $output->render_rate($question->id);
+    $html .= $output->render_rate($question->id, $studentquiz->forcerating);
 }
 
 // Finish the question form.
@@ -286,7 +286,8 @@ if ($hasanswered) {
         $ismoderator = true;
     }
 
-    $html .= $output->render_comment($cmid, $question->id, $comments, $userid, $anonymize, $ismoderator);
+    $html .= $output->render_comment($cmid, $question->id, $comments, $userid, $anonymize, $ismoderator,
+            $studentquiz->forcecommenting);
 }
 
 $html .= html_writer::end_tag('form');

--- a/styles.css
+++ b/styles.css
@@ -208,6 +208,7 @@
 }
 
 .path-mod-studentquiz .studentquiz_behaviour .rate {
+    margin-top: 20px;
     margin-bottom: 20px;
 }
 
@@ -244,6 +245,7 @@
     display: inline-block;
     unicode-bidi: bidi-override;
     height: 0;
+    vertical-align: text-top;
 }
 
 .path-mod-studentquiz .studentquiz_behaviour .rate .error {


### PR DESCRIPTION
You can now enforce Rating and Commenting (or not).

However, you only find out if it is enforced if you try saving/moving on without having rated or commented.

So the easiest thing is to be consistent with other required fields in Moodle and apply the image of the red asterisk (e.g. the "Title" field in the SQ instance set-up page).

Expected:
![image](https://user-images.githubusercontent.com/11548406/62927129-1ab67580-bde0-11e9-8014-34f0952143c4.png)

Thanks,