### PR TITLE
clarify duplication of questions due to activity instance category

### DIFF
--- a/docs/teacher/reuse.rst
+++ b/docs/teacher/reuse.rst
@@ -15,6 +15,7 @@ Its main purpose is to get overview of all questions, for importing or exporting
 
 StudentQuiz loads all questions from its question category and its subcategories.
 Thus you can also move questions into subcategories of the StudentQuiz question category to organise the questions to your liking.
+Duplicating a StudentQuiz activity will also duplicate the questions since they are part of the StudentQuiz question category.
 
 **Important**
     Use the question bank in the StudentQuiz activity, otherwise you won't be in the context of StudentQuiz and you can't see its question categories.


### PR DESCRIPTION
Helps #207 , while https://github.com/frankkoch/moodle-mod_studentquiz/blame/4ecc44112e0455ae7539eedd6acf6b7936d6565d/docs/teacher/reuse.rst#L16 already describes that the questions are part of the activity category, it is not known that having questions in a category of the activity will duplicate as well when you duplicate the activity.

Is this the best place to describe that?