### PR TITLE
Incorrect comment deletion period helptext

### DIFF
--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -441,7 +441,7 @@ $string['setting_question_publishing_help'] = 'Published questions appear in the
 $string['setting_question_publishing_automatic'] = 'Automatically publish new questions';
 $string['setting_question_publishing_require_approval'] = 'Require approval before publishing';
 $string['settings_commentdeletionperiod'] = 'Comment deletion period (minutes)';
-$string['settings_commentdeletionperiod_help'] = 'Set the time period (in minutes) that the Delete button will be available to students to delete their own comment (or response to a comment) once it is posted. Values between 0-60 minutes are allowed, with the default being 10. If the deletion period is set to 0, students are unable to delete their own comments. Note that teachers and administrators will always be able to delete student comments, and also see the content of any deleted comment.';
+$string['settings_commentdeletionperiod_help'] = 'Set the time period (in minutes) that the Delete button will be available to students to delete their own comment (or response to a comment) once it is posted. Values between 0-60 minutes are allowed, with the default being %%%STUDENTQUIZ_PERIOD_PLACEHOLDER%%%. If the deletion period is set to 0, students are unable to delete their own comments. Note that teachers and administrators will always be able to delete student comments, and also see the content of any deleted comment.';
 $string['settings_reportingemail'] = 'Email for reporting offensive comments';
 $string['settings_reportingemail_help'] = 'If this email address is supplied, then a Report link appears
 next to each comment. Users can click the link to report offensive comments. The information will be sent to this address.

--- a/mod_form.php
+++ b/mod_form.php
@@ -307,4 +307,20 @@ class mod_studentquiz_mod_form extends moodleform_mod {
         }
         return $data;
     }
+
+    /**
+     * After definition hook.
+     *
+     * @return void
+     */
+    protected function after_definition() {
+        /** @var MoodleQuickForm_select $commentdeletionperiodelement */
+        $commentdeletionperiodelement = $this->_form->getElement('commentdeletionperiod');
+        $helpbuttonhtml = $commentdeletionperiodelement->getHelpButton();
+        $helpbuttonhtml = str_replace('%%%STUDENTQUIZ_PERIOD_PLACEHOLDER%%%', get_config('studentquiz', 'commentdeletionperiod'),
+                $helpbuttonhtml);
+        $commentdeletionperiodelement->_helpbutton = $helpbuttonhtml;
+        parent::after_definition();
+    }
+
 }

--- a/settings.php
+++ b/settings.php
@@ -125,9 +125,12 @@ if ($ADMIN->fulltree) {
         '0'
     ));
 
+    $commentdeletionhelp = str_replace('%%%STUDENTQUIZ_PERIOD_PLACEHOLDER%%%',
+            \mod_studentquiz\commentarea\container::DELETION_PERIOD_DEFAULT,
+            get_string('settings_commentdeletionperiod_help', 'studentquiz'));
     $settings->add(new admin_setting_configselect('studentquiz/commentdeletionperiod',
             get_string('settings_commentdeletionperiod', 'studentquiz'),
-            get_string('settings_commentdeletionperiod_help', 'studentquiz'),
+            $commentdeletionhelp,
             \mod_studentquiz\commentarea\container::DELETION_PERIOD_DEFAULT,
             \mod_studentquiz\commentarea\container::get_deletion_period_options()
     ));


### PR DESCRIPTION
Currently, the help text always said that the default value is 10 minutes, even the default setting was changed in the Admin setting