### PR TITLE
StudentQuiz: Notification control (daily/weekly digest email settings)

### DIFF
--- a/backup/moodle2/backup_studentquiz_stepslib.php
+++ b/backup/moodle2/backup_studentquiz_stepslib.php
@@ -51,7 +51,7 @@ class backup_studentquiz_activity_structure_step extends backup_questions_activi
                 'questionquantifier', 'approvedquantifier', 'ratequantifier',
                 'correctanswerquantifier', 'incorrectanswerquantifier',
                 'allowedqtypes', 'aggregated', 'excluderoles', 'forcerating', 'forcecommenting',
-                'commentdeletionperiod', 'reportingemail'
+                'commentdeletionperiod', 'reportingemail', 'digesttype', 'digestfirstday'
         ));
 
         // StudentQuiz Attempt -> User, Question usage Id.
@@ -91,6 +91,19 @@ class backup_studentquiz_activity_structure_step extends backup_questions_activi
         ]);
         $comments->add_child($comment);
         $studentquiz->add_child($comments);
+
+        // Notification -> Question, User.
+        $notifications = new backup_nested_element('notifications');
+        $notification = new backup_nested_element('notification', ['studentquizid', 'id'], [
+                'comment', 'created', 'parentid', 'deleted', 'deleteuserid', 'edited', 'edituserid'
+        ]);
+
+        // StudentQuiz -> Notification.
+        $notifications = new backup_nested_element('notifications');
+        $notification = new backup_nested_element('notification', ['studentquizid'],
+                ['content', 'recipientid', 'status', 'timetosend']);
+        $notifications->add_child($notification);
+        $studentquiz->add_child($notifications);
 
         // Define data sources.
         $studentquiz->set_source_table('studentquiz',
@@ -147,6 +160,7 @@ class backup_studentquiz_activity_structure_step extends backup_questions_activi
         $comment->annotate_ids('user', 'userid');
         $comment->annotate_ids('user', 'deleteuserid');
         $comment->annotate_ids('user', 'edituserid');
+        $notification->annotate_ids('studentquiz', 'studentquizid');
 
         // Define file annotations (we do not use itemid in this example).
         $studentquiz->annotate_files('mod_studentquiz', 'intro', null);

--- a/backup/moodle2/restore_studentquiz_stepslib.php
+++ b/backup/moodle2/restore_studentquiz_stepslib.php
@@ -82,6 +82,11 @@ class restore_studentquiz_activity_structure_step extends restore_questions_acti
             '/activity/studentquiz/questions/question');
         $paths[] = $question;
 
+        // Restore Notification meta.
+        $notification = new restore_path_element('notification',
+                '/activity/studentquiz/notifications/notification');
+        $paths[] = $notification;
+
         // Return the paths wrapped into standard activity structure.
         return $this->prepare_activity_structure($paths);
     }
@@ -218,6 +223,15 @@ class restore_studentquiz_activity_structure_step extends restore_questions_acti
         }
 
         $DB->insert_record('studentquiz_question', $data);
+    }
+
+    protected function process_notification($data) {
+        global $DB;
+
+        $data = (object) $data;
+        $data->studentquizid = $this->get_mappingid('notification', $data->studentquizid);
+
+        $DB->insert_record('studentquiz_notification', $data);
     }
 
     /**

--- a/classes/event/studentquiz_digest_changed.php
+++ b/classes/event/studentquiz_digest_changed.php
@@ -1,0 +1,119 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The mod_studentquiz digest changed event
+ *
+ * @package    mod_studentquiz
+ * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_studentquiz\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+use mod_studentquiz\utils;
+use moodle_url;
+
+/**
+ * The mod_studentquiz digest changed event
+ *
+ * @property-read array $other {
+ *      Extra information about the event.
+ *
+ *      - int newdigesttype: The type of the new digest
+ *      - int olddigesttype: The type of the old digest
+ *      - int olddigestfirstday: The type of the old digest first day
+ * }
+ *
+ * @package    mod_studentquiz
+ * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class studentquiz_digest_changed extends \core\event\base {
+
+    /**
+     * Initialize the event
+     */
+    protected function init() {
+        $this->data['crud'] = 'u';
+        $this->data['edulevel'] = self::LEVEL_TEACHING;
+        $this->data['objecttable'] = 'studentquiz';
+    }
+
+    /**
+     * Get description
+     *
+     * @return string get description
+     */
+    public function get_description() {
+        return 'On course: ' . $this->courseid . ' studentquizid: ' . $this->objectid . ' digest type was changed from ' .
+                $this->other['olddigesttype'] . ' to ' . $this->other['newdigesttype'];
+    }
+
+    /**
+     * Get url
+     *
+     * @return moodle_url view.php url
+     */
+    public function get_url() {
+        return new moodle_url('/mod/studentquiz/view.php', ['id' => $this->objectid]);
+    }
+
+    /**
+     * This is used when restoring course logs where it is required that we
+     * map the objectid to it's new value in the new course.
+     *
+     * @return array the name of the restore mapping the objectid links to
+     */
+    public static function get_objectid_mapping() {
+        return ['db' => 'studentquiz', 'restore' => 'studentquiz'];
+    }
+
+    /**
+     * Custom validations.
+     *
+     * @return void
+     */
+    protected function validate_data() {
+        if (!isset($this->other['olddigesttype'])) {
+            throw new \coding_exception('The \'olddigesttype\' must be set in \'other\'.');
+        }
+        if (!isset($this->other['newdigesttype'])) {
+            throw new \coding_exception('The \'newdigesttype\' must be set in \'other\'.');
+        }
+        if ($this->other['olddigesttype'] == utils::WEEKLY_DIGEST_TYPE && !isset($this->other['olddigestfirstday'])) {
+            throw new \coding_exception('The \'olddigestfirstday\' must be set in \'other\'.');
+        }
+    }
+
+    /**
+     * This is used when restoring course logs where it is required that we
+     * map the information in 'other' to it's new value in the new course.
+     *
+     * @return array|bool an array of other values and their corresponding mapping
+     */
+    public static function get_other_mapping() {
+        $othermapped = [];
+        $othermapped['olddigesttype'] = ['db' => 'studentquiz', 'restore' => 'studentquiz'];
+        $othermapped['newdigesttype'] = ['db' => 'studentquiz', 'restore' => 'studentquiz'];
+        $othermapped['newdigesttype'] = ['db' => 'studentquiz', 'restore' => 'studentquiz'];
+        $othermapped['olddigestfirstday'] = ['db' => 'studentquiz', 'restore' => 'studentquiz'];
+
+        return $othermapped;
+    }
+}

--- a/classes/task/send_digest_notification_task.php
+++ b/classes/task/send_digest_notification_task.php
@@ -1,0 +1,133 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A scheduled task for sending digest notification.
+ *
+ * @package    mod_studentquiz
+ * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_studentquiz\task;
+
+use core\message\message;
+use moodle_url;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * A scheduled task for sending digest notification.
+ *
+ * @package    mod_studentquiz
+ * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class send_digest_notification_task extends \core\task\scheduled_task {
+
+    /**
+     * Get a descriptive name for this task (shown to admins).
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('scheduled_task_send_digest_notification', 'mod_studentquiz');
+    }
+
+    /**
+     * Send out messages.
+     */
+    public function execute() {
+        global $DB, $USER, $PAGE;
+
+        mtrace('Sending digest notification for StudentQuiz');
+        $renderer = $PAGE->get_renderer('mod_studentquiz');
+        date_default_timezone_set('UTC');
+
+        $sql = 'SELECT DISTINCT sn.studentquizid, 1
+                  FROM {studentquiz_notification} sn
+                 WHERE sn.timetosend <= :timetosend
+                       AND status = :status';
+        $studentquizids = $DB->get_records_sql_menu($sql, ['timetosend' => strtotime(date('Y-m-d')), 'status' => 0]);
+
+        $recordids = [];
+        $messagetotal = 0;
+        foreach ($studentquizids as $studentquizid => $notused) {
+            $notificationqueues = $DB->get_recordset_select('studentquiz_notification',
+                    'timetosend <= :timetosend AND status = :status AND studentquizid = :studentquizid',
+                    ['timetosend' => strtotime(date('Y-m-d')), 'status' => 0, 'studentquizid' => $studentquizid]);
+            $studentquiz = $DB->get_record('studentquiz', ['coursemodule' => $studentquizid]);
+
+            $recipients = [];
+            foreach ($notificationqueues as $notificationqueue) {
+                if (!array_key_exists($notificationqueue->recipientid, $recipients)) {
+                    $recipients[$notificationqueue->recipientid] = [];
+                }
+                $recipients[$notificationqueue->recipientid][] = unserialize($notificationqueue->content);
+                $recordids[] = $notificationqueue->id;
+            }
+            $notificationqueues->close();
+
+            foreach ($recipients as $userid => $datas) {
+                $contentdata = [
+                        'recipientname' => $datas[0]['messagedata']->recepientname,
+                        'digesttype' => $studentquiz->digesttype == 1 ? 'Daily' : 'Weekly',
+                        'modulename' => $studentquiz->name,
+                        'activityurl' => (new moodle_url('/mod/studentquiz/view.php',
+                                ['cmid' => $studentquiz->coursemodule]))->out(),
+                        'notifications' => []
+                ];
+                $total = 0;
+                foreach ($datas as $data) {
+                    $total++;
+                    $contentdata['notifications'][] = [
+                            'seq' => $total,
+                            'timestamp' => $data['messagedata']->timestamp,
+                            'questionname' => $data['messagedata']->questionname,
+                            'actiontype' => $data['eventname'],
+                            'actorname' => $data['messagedata']->actorname
+                    ];
+                }
+                $fullmessagehtml = $renderer->render_from_template('mod_studentquiz/digest_email_notification', $contentdata);
+
+                $eventdata = new message();
+                $eventdata->component = 'mod_studentquiz';
+                $eventdata->name = 'questionchanged';
+                $eventdata->notification = 1;
+                $eventdata->courseid = 0;
+                $eventdata->userfrom = $USER; // Was done by cron_setup_user().
+                $eventdata->userto = \core_user::get_user($userid);
+                $eventdata->subject = get_string('emaildigestsubject', 'mod_studentquiz');
+                $eventdata->smallmessage = $fullmessagehtml;
+                $eventdata->fullmessage = $fullmessagehtml;
+                $eventdata->fullmessageformat = FORMAT_HTML;
+                $eventdata->fullmessagehtml = $fullmessagehtml;
+
+                message_send($eventdata);
+                $messagetotal++;
+                mtrace("Notification to {$datas[0]['messagedata']->recepientname} has been sent", 1);
+            }
+        }
+
+        if (!empty($recordids)) {
+            list($insql, $inparams) = $DB->get_in_or_equal($recordids, SQL_PARAMS_NAMED);
+            $insql = ' id ' . $insql;
+            $DB->set_field_select('studentquiz_notification', 'status', 1, $insql, $inparams);
+        }
+
+        mtrace("Sent {$messagetotal} messages!");
+    }
+}

--- a/classes/task/send_no_digest_notification_task.php
+++ b/classes/task/send_no_digest_notification_task.php
@@ -1,0 +1,80 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * An adhoc task for sending no digest notification.
+ *
+ * @package    mod_studentquiz
+ * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_studentquiz\task;
+
+use core\message\message;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * An adhoc task for sending no digest notification.
+ *
+ * @package    mod_studentquiz
+ * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class send_no_digest_notification_task extends \core\task\adhoc_task {
+
+    /**
+     * Send out messages.
+     */
+    public function execute() {
+        global $PAGE;
+        $data = $this->get_custom_data();
+
+        mtrace('Sending notification for StudentQuiz for question ' .
+                $data->messagedata->questionname . ' to ' . $data->messagedata->recepientname);
+
+        $renderer = $PAGE->get_renderer('mod_studentquiz');
+        $contentdata = [
+                'recipientname' => $data->messagedata->recepientname,
+                'questionname' => $data->messagedata->questionname,
+                'modulename' => $data->messagedata->modulename,
+                'coursename' => $data->messagedata->coursename,
+                'actorname' => $data->messagedata->actorname,
+                'timestamp' => $data->messagedata->timestamp,
+                'questionurl' => $data->messagedata->questionurl,
+                'eventname' => $data->eventname
+        ];
+        $fullmessagehtml = $renderer->render_from_template('mod_studentquiz/single_email_notification', $contentdata);
+
+        $eventdata = new message();
+        $eventdata->component = 'mod_studentquiz';
+        $eventdata->name = 'questionchanged';
+        $eventdata->notification = 1;
+        $eventdata->courseid = $data->courseid;
+        $eventdata->userfrom = $data->submitter;
+        $eventdata->userto = $data->recipient;
+        $eventdata->subject = get_string('emaildigestsubject', 'mod_studentquiz');
+        $eventdata->smallmessage = $fullmessagehtml;
+        $eventdata->fullmessage = $fullmessagehtml;
+        $eventdata->fullmessageformat = FORMAT_HTML;
+        $eventdata->fullmessagehtml = $fullmessagehtml;
+        $eventdata->contexturl = $data->questionurl;
+        $eventdata->contexturlname = $data->questionname;
+
+        return message_send($eventdata);
+    }
+}

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -38,6 +38,13 @@ use external_single_structure;
  */
 class utils {
 
+    /** @var int No digest type */
+    const NO_DIGEST_TYPE = 0;
+    /** @var int Daily digest type */
+    const DAILY_DIGEST_TYPE = 1;
+    /** @var int Weekly digest type */
+    const WEEKLY_DIGEST_TYPE = 2;
+
     /**
      * Get Comment Area web service comment reply structure.
      *
@@ -237,5 +244,42 @@ class utils {
                 'edited' => time(),
                 'edituserid' => $guestuserid
         ];
+    }
+
+    /**
+     * Calculate and return the timestamp of timetosend
+     *
+     * @param int $digestfirstday First day of the week
+     *
+     * @return int the timestamp to send
+     */
+    public static function calculcate_notification_time_to_send(int $digestfirstday): int {
+        date_default_timezone_set('UTC');
+        $timetosend = 0;
+        switch ($digestfirstday) {
+            case 0:
+                $timetosend = strtotime('next sunday', mktime(0, 0, 0));
+                break;
+            case 1:
+                $timetosend = strtotime('next monday', mktime(0, 0, 0));
+                break;
+            case 2:
+                $timetosend = strtotime('next tuesday', mktime(0, 0, 0));
+                break;
+            case 3:
+                $timetosend = strtotime('next wednesday', mktime(0, 0, 0));
+                break;
+            case 4:
+                $timetosend = strtotime('next thursday', mktime(0, 0, 0));
+                break;
+            case 5:
+                $timetosend = strtotime('next friday', mktime(0, 0, 0));
+                break;
+            case 6:
+                $timetosend = strtotime('next saturday', mktime(0, 0, 0));
+                break;
+        }
+
+        return $timetosend;
     }
 }

--- a/db/access.php
+++ b/db/access.php
@@ -111,29 +111,7 @@ $capabilities = array(
         ),
     ),
     // Notifications.
-    'mod/studentquiz:emailnotifychanged' => array(
-        'riskbitmask' => RISK_SPAM,
-        'captype' => 'write',
-        'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
-            'student'        => CAP_ALLOW,
-            'teacher'        => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
-            'manager'        => CAP_ALLOW,
-        ),
-    ),
-    'mod/studentquiz:emailnotifydeleted' => array(
-        'riskbitmask' => RISK_SPAM,
-        'captype' => 'write',
-        'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
-            'student'        => CAP_ALLOW,
-            'teacher'        => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
-            'manager'        => CAP_ALLOW,
-        ),
-    ),
-    'mod/studentquiz:emailnotifyapproved' => array(
+    'mod/studentquiz:emailnotifyquestion' => array(
         'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,

--- a/db/events.php
+++ b/db/events.php
@@ -33,5 +33,9 @@ $observers = [
         [
                 'eventname' => '\core\event\question_moved',
                 'callback' => 'mod_studentquiz_observer::question_moved'
+        ],
+        [
+                'eventname' => '\mod_studentquiz\event\studentquiz_digest_changed',
+                'callback' => 'mod_studentquiz_observer::digest_changed'
         ]
 ];

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/studentquiz/db" VERSION="20200430" COMMENT="mod_studentquiz database layout"
+<XMLDB PATH="mod/studentquiz/db" VERSION="20200504" COMMENT="mod_studentquiz database layout"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -33,6 +33,8 @@
         <FIELD NAME="publishnewquestion" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Setting to automatically publish new created question"/>
         <FIELD NAME="commentdeletionperiod" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="10" SEQUENCE="false" COMMENT="Define deletion period for user can able to delete a comment."/>
         <FIELD NAME="reportingemail" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Email address for reporting unacceptable comments"/>
+        <FIELD NAME="digesttype" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Email digest type"/>
+        <FIELD NAME="digestfirstday" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="First day of week"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -132,6 +134,21 @@
         <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
         <KEY NAME="questionusageid" TYPE="foreign" FIELDS="questionusageid" REFTABLE="question_usages" REFFIELDS="id"/>
         <KEY NAME="categoryid" TYPE="foreign" FIELDS="categoryid" REFTABLE="question_categories" REFFIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="studentquiz_notification" COMMENT="Notification queue">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="studentquizid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="StudentQuiz id"/>
+        <FIELD NAME="content" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Notification content"/>
+        <FIELD NAME="recipientid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Recipient Id"/>
+        <FIELD NAME="status" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Status of the notification"/>
+        <FIELD NAME="timetosend" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time to send the notification"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="studentquizid" TYPE="foreign" FIELDS="studentquizid" REFTABLE="studentquiz" REFFIELDS="id"/>
+        <KEY NAME="recipientid" TYPE="foreign" FIELDS="recipientid" REFTABLE="user" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/db/messages.php
+++ b/db/messages.php
@@ -25,29 +25,9 @@
 defined('MOODLE_INTERNAL') || die();
 
 $messageproviders = array(
-    // Notify student that someone has edited his question. (Info to question author).
-    'changed' => array(
-        'capability' => 'mod/studentquiz:emailnotifychanged'
-    ),
-    // Notify student that someone has deleted his question. (Info to question author).
-    'deleted' => array(
-        'capability' => 'mod/studentquiz:emailnotifydeleted'
-    ),
-    // Notify student that someone has approved his question. (Info to question author).
-    'approved' => array(
-        'capability' => 'mod/studentquiz:emailnotifyapproved'
-    ),
-    // Notify student that someone has disapproved his question. (Info to question author.)
-    'disapproved' => array(
-        'capability' => 'mod/studentquiz:emailnotifyapproved'
-    ),
-    // Notify student that someone has unhidden his question. (Info to question author.)
-    'unhidden' => array(
-        'capability' => 'mod/studentquiz:emailnotifyapproved'
-    ),
-    // Notify student that someone has hidden his question. (Info to question author.)
-    'hidden' => array(
-        'capability' => 'mod/studentquiz:emailnotifyapproved'
+    // Notify student that someone has approved, disapproved, hide, unhide, or changed his question. (Info to question author).
+    'questionchanged' => array(
+        'capability' => 'mod/studentquiz:emailnotifyquestion'
     ),
     // Notify student that someone has commented to his question. (Info to question author).
     'commentadded' => array(

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -24,4 +24,14 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$tasks = array();
+$tasks = [
+        [
+                'classname' => 'mod_studentquiz\task\send_digest_notification_task',
+                'blocking' => 0,
+                'minute' => '0',
+                'hour' => '0',
+                'day' => '*',
+                'month' => '*',
+                'dayofweek' => '*'
+        ]
+];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -626,5 +626,55 @@ function xmldb_studentquiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2020043000, 'studentquiz');
     }
 
+    if ($oldversion < 2020050400) {
+
+        $table = new xmldb_table('studentquiz');
+        // Define field digesttype to be added to studentquiz.
+        $field = new xmldb_field('digesttype', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'reportingemail');
+
+        // Conditionally launch add field digesttype.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field digestfirstday to be added to studentquiz.
+        $field = new xmldb_field('digestfirstday', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'digesttype');
+
+        // Conditionally launch add field digestfirstday.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Studentquiz savepoint reached.
+        upgrade_mod_savepoint(true, 2020050400, 'studentquiz');
+    }
+
+    if ($oldversion < 2020050404) {
+
+        // Define table studentquiz_notification to be created.
+        $table = new xmldb_table('studentquiz_notification');
+
+        // Adding fields to table studentquiz_notification.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null, null);
+        $table->add_field('studentquizid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'id');
+        $table->add_field('content', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null, 'studentquizid');
+        $table->add_field('recipientid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null, 'content');
+        $table->add_field('status', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'recipientid');
+        $table->add_field('timetosend', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0', 'status');
+
+        // Adding keys to table studentquiz_notification.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('studentquizid', XMLDB_KEY_FOREIGN, ['studentquizid'], 'studentquiz', ['id']);
+        $table->add_key('recipientid', XMLDB_KEY_FOREIGN, ['recipientid'], 'user', ['id']);
+
+        // Conditionally launch create table for studentquiz_notification.
+        if (!$dbman->table_exists('studentquiz_notification')) {
+            $dbman->create_table($table);
+        }
+
+        // Studentquiz savepoint reached.
+        upgrade_mod_savepoint(true, 2020050404, 'studentquiz');
+    }
+
     return true;
 }

--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -75,20 +75,7 @@ $string['describe_not_creator'] = 'This is not your comment.';
 $string['describe_out_of_time_delete'] = 'This comment is out of time to delete';
 $string['describe_out_of_time_edit'] = 'This comment is out of time to edit';
 $string['editcomment'] = 'Edit comment';
-$string['emailapprovedbody'] = 'Dear {$a->recepientname},
-
-Your question \'{$a->questionname}\' in StudentQuiz activity \'{$a->modulename}\' in course \'{$a->coursename}\' has been approved by \'{$a->actorname}\' at \'{$a->timestamp}\'.
-
-You can review this question at: {$a->questionurl}.';
-$string['emailapprovedsmall'] = 'Your question \'{$a->questionname}\' has been approved by {$a->actorname}.';
-$string['emailapprovedsubject'] = 'Question has been approved: {$a->questionname}';
-$string['emailchangedbody'] = 'Dear {$a->recepientname},
-
-Your question \'{$a->questionname}\' in StudentQuiz activity \'{$a->modulename}\' in course \'{$a->coursename}\' has been modified by \'{$a->actorname}\' at \'{$a->timestamp}\'.
-
-You can review this question at: {$a->questionurl}.';
-$string['emailchangedsmall'] = 'Your question \'{$a->questionname}\' has been modified by {$a->actorname}.';
-$string['emailchangedsubject'] = 'Question has been modified: {$a->questionname}';
+$string['emailautomationnote'] = 'Please note that this is an automated system message – this email address is not monitored.';
 $string['emailcommentaddedbody'] = 'Dear {$a->recepientname},
 
 Your question \'{$a->questionname}\' in StudentQuiz activity \'{$a->modulename}\' in course \'{$a->coursename}\' has been commented by \'{$a->actorname}\' at \'{$a->timestamp}\'.
@@ -108,11 +95,6 @@ The comment was: \'{$a->commenttext}\'
 You can review this question at: {$a->questionurl}.';
 $string['emailcommentdeletedsmall'] = 'The comment to your question \'{$a->questionname}\' has been deleted by {$a->actorname}.';
 $string['emailcommentdeletedsubject'] = 'Comment has been deleted to question: {$a->questionname}';
-$string['emaildeletedbody'] = 'Dear {$a->recepientname},
-
-Your question \'{$a->questionname}\' in StudentQuiz activity \'{$a->modulename}\' in course \'{$a->coursename}\' has been deleted by \'{$a->actorname}\' at \'{$a->timestamp}\'.';
-$string['emaildeletedsmall'] = 'Your question \'{$a->questionname}\' has been deleted by {$a->actorname}.';
-$string['emaildeletedsubject'] = 'Question has been deleted: {$a->questionname}';
 $string['emailminecommentdeletedbody'] = 'Dear {$a->recepientname},
 
 Your comment on \'{$a->commenttime}\' to the question \'{$a->questionname}\' in StudentQuiz activity \'{$a->modulename}\' in course \'{$a->coursename}\' has been deleted by \'{$a->actorname}\' at \'{$a->timestamp}\'.
@@ -122,30 +104,13 @@ The comment was: \'{$a->commenttext}\'
 You can review this question at: {$a->questionurl}.';
 $string['emailminecommentdeletedsmall'] = 'Your comment to question \'{$a->questionname}\' has been deleted by {$a->actorname}.';
 $string['emailminecommentdeletedsubject'] = 'Comment has been deleted to question: {$a->questionname}';
-$string['emaildisapprovedbody'] = 'Dear {$a->recepientname},
-
-Your question \'{$a->questionname}\' in StudentQuiz activity \'{$a->modulename}\' in course \'{$a->coursename}\' has been disapproved by \'{$a->actorname}\' at \'{$a->timestamp}\'.
-
-You can review this question at: {$a->questionurl}.';
-$string['emaildisapprovedsmall'] = 'Your question \'{$a->questionname}\' has been disapproved by {$a->actorname}.';
-$string['emaildisapprovedsubject'] = 'Question has been disapproved: {$a->questionname}';
-
-$string['emailhiddenbody'] = 'Dear {$a->recepientname},
-
-Your question \'{$a->questionname}\' in StudentQuiz activity \'{$a->modulename}\' in course \'{$a->coursename}\' has been hidden by \'{$a->actorname}\' at \'{$a->timestamp}\'.
-
-You can review this question at: {$a->questionurl}.';
-$string['emailhiddensmall'] = 'Your question \'{$a->questionname}\' has been hidden by {$a->actorname}.';
-$string['emailhiddensubject'] = 'Question has been hidden: {$a->questionname}';
-
-$string['emailunhiddenbody'] = 'Dear {$a->recepientname},
-
-Your question \'{$a->questionname}\' in StudentQuiz activity \'{$a->modulename}\' in course \'{$a->coursename}\' has been unhidden by \'{$a->actorname}\' at \'{$a->timestamp}\'.
-
-You can review this question at: {$a->questionurl}.';
-$string['emailunhiddensmall'] = 'Your question \'{$a->questionname}\' has been unhidden by {$a->actorname}.';
-$string['emailunhiddensubject'] = 'Question has been unhidden: {$a->questionname}';
-
+$string['emailsinglebody'] = 'Your question <b>{$a->questionname}</b> in StudentQuiz activity <b>{$a->modulename}</b> in course <b>{$a->coursename}</b> has been {$a->eventname} by <b>{$a->actorname}</b> at <b>{$a->timestamp}</b>.';
+$string['emailsinglebody_reviewlink'] = 'You can review this question at: ';
+$string['emaildigestbody'] = 'This is your {$a->digesttype} digest of notifications for the <b>{$a->modulename}</b> StudentQuiz activity, available here: ';
+$string['emaildigestbody_section_title'] = 'Notification {$a->seq}, {$a->timestamp}';
+$string['emaildigestbody_section_content'] = 'Your question <b>{$a->questionname}</b> has been <b>{$a->actiontype}</b> by <b>{$a->actorname}</b>';
+$string['emaildigestsubject'] = 'StudentQuiz Digest Notification';
+$string['emailsalutation'] = 'Dear {$a},';
 $string['editorplaceholder'] = 'Enter your comment here ...';
 $string['error_form_validation'] = '{$a}';
 $string['error_sendalert'] = 'There was an error sending your report to {$a}.
@@ -390,6 +355,7 @@ used on the StudentQuiz for reporting unacceptable comment.';
 $string['report_comment_link_text'] = 'Preview here';
 $string['review_button'] = 'Review';
 $string['savechanges'] = 'Save changes';
+$string['scheduled_task_send_digest_notification'] = 'Send digest notification';
 $string['settings_allowallqtypes'] = 'Allow all question types';
 $string['settings_allowedqtypes'] = 'Allowed question types';
 $string['settings_allowedqtypes_help'] = 'Limit the allowed question types to the selected entries';
@@ -403,6 +369,13 @@ $string['settings_availability_close_answering_from'] = 'Closed for answering fr
 $string['settings_availability_close_submission_from'] = 'Closed for question submission from';
 $string['settings_availability_open_answering_from'] = 'Open for answering from';
 $string['settings_availability_open_submission_from'] = 'Open for question submission from';
+$string['settings_email_digest_type'] = 'Email digest type';
+$string['settings_email_digest_type_help'] = 'StudentQuiz has various notifications that you can enable, such as informing the student question-author of a state change (e.g. a teacher has approved one of their questions). You can use this setting to specify the frequency of these notifications. Digest emails will only be sent when there is at least one notification in the set period';
+$string['settings_email_digest_type_no_digest'] = 'No digest (single email per action)';
+$string['settings_email_digest_type_daily_digest'] = 'Daily digest';
+$string['settings_email_digest_type_weekly_digest'] = 'Weekly digest';
+$string['settings_email_digest_first_day'] = 'First day of week?';
+$string['settings_email_digest_first_day_help'] = 'If you have selected a weekly digest, this option allows you to define the first day (beginning at 00h:00m:00s of that day) of the seven day period. This is especially useful if the activity starts mid-week, for example.';
 $string['settings_excluderoles'] = 'Exclude roles in ranking';
 $string['settings_excluderoles_label'] = 'Roles in ranking to exclude';
 $string['settings_excluderoles_help'] = 'Selected roles are hidden in the rankings, enrolled users in these roles can still participate normally in the activity';
@@ -416,6 +389,7 @@ $string['settings_lastcorrectanswerquantifier_label'] = 'Points for latest corre
 $string['settings_lastincorrectanswerquantifier'] = 'Latest wrong answer factor';
 $string['settings_lastincorrectanswerquantifier_help'] = 'Points for each wrong or partially wrong answer on the last attempt';
 $string['settings_lastincorrectanswerquantifier_label'] = 'Points for latest wrong answers';
+$string['settings_notification'] = 'Notification settings';
 $string['settings_questionquantifier'] = 'Created question factor';
 $string['settings_questionquantifier_help'] = 'Points for each created question';
 $string['settings_questionquantifier_label'] = 'Points for each question created';

--- a/lib.php
+++ b/lib.php
@@ -178,6 +178,23 @@ function studentquiz_update_instance(stdClass $studentquiz, mod_studentquiz_mod_
         $studentquiz->commentdeletionperiod = get_config('studentquiz', 'commentediting_deletionperiod');
     }
 
+    $currentdata = $DB->get_record('studentquiz', ['id' => $studentquiz->instance]);
+    if ($currentdata->digesttype != $studentquiz->digesttype) {
+        $params = [
+                'objectid' => $currentdata->coursemodule,
+                'context' => context_module::instance($currentdata->coursemodule),
+                'other' => [
+                        'olddigesttype' => $currentdata->digesttype,
+                        'newdigesttype' => $studentquiz->digesttype
+                ]
+        ];
+        if ($currentdata->digesttype == 2) {
+            $params['other']['olddigestfirstday'] = $currentdata->digestfirstday;
+        }
+        $event = \mod_studentquiz\event\studentquiz_digest_changed::create($params);
+        $event->trigger();
+    }
+
     $result = $DB->update_record('studentquiz', $studentquiz);
 
     return $result;

--- a/mod_form.php
+++ b/mod_form.php
@@ -225,6 +225,33 @@ class mod_studentquiz_mod_form extends moodleform_mod {
         $mform->addElement('date_time_selector', 'closeansweringfrom',
                 get_string('settings_availability_close_answering_from', 'studentquiz'), ['optional' => true]);
 
+        // Notification.
+        $mform->addElement('header', 'notification', get_string('settings_notification', 'studentquiz'));
+        // Field email digest type.
+        $digesttypes = [
+                0 => get_string('settings_email_digest_type_no_digest', 'studentquiz'),
+                1 => get_string('settings_email_digest_type_daily_digest', 'studentquiz'),
+                2 => get_string('settings_email_digest_type_weekly_digest', 'studentquiz')
+        ];
+        $mform->addElement('select', 'digesttype', get_string('settings_email_digest_type', 'studentquiz'),
+                $digesttypes);
+        $mform->addHelpButton('digesttype', 'settings_email_digest_type', 'studentquiz');
+
+        // Field first day of week.
+        $daysofweek = [
+                0 => get_string('sunday', 'calendar'),
+                1 => get_string('monday', 'calendar'),
+                2 => get_string('tuesday', 'calendar'),
+                3 => get_string('wednesday', 'calendar'),
+                4 => get_string('thursday', 'calendar'),
+                5 => get_string('friday', 'calendar'),
+                6 => get_string('saturday', 'calendar')
+        ];
+        $mform->addElement('select', 'digestfirstday', get_string('settings_email_digest_first_day', 'studentquiz'), $daysofweek);
+        $mform->addHelpButton('digestfirstday', 'settings_email_digest_first_day', 'studentquiz');
+        $mform->setDefault('digestfirstday', 1);
+        $mform->disabledIf('digestfirstday', 'digesttype', 'neq', 2);
+
         // Add standard elements, common to all modules.
         $this->standard_coursemodule_elements();
 

--- a/templates/digest_email_notification.mustache
+++ b/templates/digest_email_notification.mustache
@@ -1,0 +1,63 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template mod_studentquiz/digest_email_notification
+
+    Template for rendering digest_email_notification.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * recipientname
+    * digesttype
+    * modulename
+    * activityurl
+    * notifications - array of notifications
+        * seq
+        * timestamp
+        * questionname
+        * actiontype
+        * actorname
+
+}}
+<div>
+    <p>{{# str }} emailautomationnote, studentquiz {{/ str }}</p><br>
+    <p>{{# str }} emailsalutation, studentquiz, {{ recipientname }} {{/ str }}</p>
+    <p>
+        {{# str }} emaildigestbody, studentquiz, { "digesttype": {{# quote }} {{ digesttype }} {{/ quote }}, "modulename": {{# quote }} {{ modulename }}  {{/ quote }}} {{/ str }}<a href="{{ activityurl }}">{{ activityurl }}</a>
+    </p>
+    <div>=====================================================================</div>
+
+    {{#notifications}}
+        <div>
+            <div>---------------------------------------------------------------------</div>
+            <div>{{# str }} emaildigestbody_section_title, studentquiz, { "seq": {{# quote }} {{ seq }} {{/ quote }}, "timestamp": {{# quote }} {{ timestamp }}  {{/ quote }}} {{/ str }}</div>
+            <div>---------------------------------------------------------------------</div>
+            <div>{{# str }} emaildigestbody_section_content, studentquiz, {
+                "questionname": {{# quote }} {{ questionname }} {{/ quote }},
+                "actiontype": {{# quote }} {{ actiontype }} {{/ quote }},
+                "actorname": {{# quote }} {{ actorname }} {{/ quote }}
+                } {{/ str }}
+            </div>
+        </div>
+        <br>
+    {{/notifications}}
+</div>

--- a/templates/single_email_notification.mustache
+++ b/templates/single_email_notification.mustache
@@ -1,0 +1,53 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template mod_studentquiz/single_email_notification
+
+    Template for rendering single_email_notification.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * recipientname
+    * questionname
+    * modulename
+    * coursename
+    * eventname
+    * actorname
+    * timestamp
+    * questionurl
+}}
+<div>
+    <p>{{# str }} emailautomationnote, studentquiz {{/ str }}</p><br>
+    <p>{{# str }} emailsalutation, studentquiz, {{ recipientname }} {{/ str }}</p>
+    <p>
+        {{# str }} emailsinglebody, studentquiz, {
+            "questionname": {{# quote }} {{ questionname }} {{/ quote }},
+            "modulename": {{# quote }} {{ modulename }} {{/ quote }},
+            "coursename": {{# quote }} {{ coursename }} {{/ quote }},
+            "eventname": {{# quote }} {{ eventname }} {{/ quote }},
+            "actorname": {{# quote }} {{ actorname }} {{/ quote }},
+            "timestamp": {{# quote }} {{ timestamp }} {{/ quote }}
+            }
+        {{/ str }}
+    </p>
+    <p>{{# str }} emailsinglebody_reviewlink, studentquiz {{/ str }}<a href="{{ questionurl }}">{{ questionurl }}</a>.</p>
+</div>

--- a/tests/cron_test.php
+++ b/tests/cron_test.php
@@ -1,0 +1,200 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cron test.
+ *
+ * @package    mod_studentquiz
+ * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Cron test.
+ *
+ * @package    mod_studentquiz
+ * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_studentquiz_cron_testcase extends advanced_testcase {
+
+    protected $course;
+    protected $student1;
+    protected $student2;
+    protected $teacher;
+    protected $studentquizdata;
+    protected $cmid;
+    protected $studentquiz;
+    protected $questions;
+
+    protected function setUp() {
+        global $DB;
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator();
+        $questiongenerator = $generator->get_plugin_generator('core_question');
+
+        // Prepare course.
+        $this->course = $generator->create_course();
+
+        // Prepare users.
+        $this->student1 =
+                $generator->create_user(['firstname' => 'Student', 'lastname' => '1', 'email' => 'student1@localhost.com']);
+        $this->student2 =
+                $generator->create_user(['firstname' => 'Student', 'lastname' => '2', 'email' => 'student2@localhost.com']);
+        $this->teacher = $generator->create_user(['email' => 'teacher@localhost.com']);
+
+        // Users enrolments.
+        $studentrole = $DB->get_record('role', ['shortname' => 'student']);
+        $teacherrole = $DB->get_record('role', ['shortname' => 'editingteacher']);
+        $this->getDataGenerator()->enrol_user($this->student1->id, $this->course->id, $studentrole->id, 'manual');
+        $this->getDataGenerator()->enrol_user($this->student2->id, $this->course->id, $studentrole->id, 'manual');
+        $this->getDataGenerator()->enrol_user($this->teacher->id, $this->course->id, $teacherrole->id, 'manual');
+
+        // Prepare studentquiz.
+        $this->studentquizdata = [
+                'course' => $this->course->id,
+                'anonymrank' => false,
+                'questionquantifier' => 10,
+                'approvedquantifier' => 5,
+                'ratequantifier' => 3,
+                'correctanswerquantifier' => 2,
+                'incorrectanswerquantifier' => -1,
+        ];
+
+        $this->cmid = $generator->create_module('studentquiz', $this->studentquizdata)->cmid;
+        $this->studentquiz = mod_studentquiz_load_studentquiz($this->cmid, context_module::instance($this->cmid)->id);
+
+        // Prepare question.
+        $this->setUser($this->student1);
+        $this->setUser($this->student2);
+        $this->questions[0] = $questiongenerator->create_question('truefalse', null,
+                ['name' => 'Student 1 Question', 'category' => $this->studentquiz->categoryid]);
+        $this->questions[1] = $questiongenerator->create_question('truefalse', null,
+                ['name' => 'Student 2 Question', 'category' => $this->studentquiz->categoryid]);
+        question_bank::load_question($this->questions[0]->id);
+        question_bank::load_question($this->questions[1]->id);
+        $DB->insert_record('studentquiz_question', (object) ['questionid' => $this->questions[0]->id, 'state' => 0]);
+        $DB->insert_record('studentquiz_question', (object) ['questionid' => $this->questions[1]->id, 'state' => 1]);
+    }
+
+    /**
+     * Test send_no_digest_notification_task
+     */
+    public function test_send_no_digest_notification_task() {
+        global $DB;
+        $question = $DB->get_record('question', ['id' => $this->questions[0]->id],
+                'id, name, timemodified, createdby, modifiedby');
+        $notifydata = mod_studentquiz_prepare_notify_data($question, $this->student1, get_admin(), $this->course,
+                get_coursemodule_from_id('studentquiz', $this->cmid));
+        $customdata = [
+                'eventname' => 'questionchanged',
+                'courseid' => $this->course->id,
+                'submitter' => get_admin(),
+                'recipient' => $this->student1,
+                'messagedata' => $notifydata,
+                'questionurl' => $notifydata->questionurl,
+                'questionname' => $notifydata->questionname,
+        ];
+
+        // Execute the cron.
+        ob_start();
+        cron_setup_user();
+        $cron = new \mod_studentquiz\task\send_no_digest_notification_task();
+        $cron->set_custom_data($customdata);
+        $cron->set_component('mod_studentquiz');
+        $cron->execute();
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertContains('Sending notification for StudentQuiz for question ' .
+                $question->name . ' to ' .
+                $notifydata->recepientname, $output);
+
+        $question = $DB->get_record('question', ['id' => $this->questions[1]->id],
+                'id, name, timemodified, createdby, modifiedby');
+        $notifydata = mod_studentquiz_prepare_notify_data($question, $this->student2, get_admin(), $this->course,
+                get_coursemodule_from_id('studentquiz', $this->cmid));
+        $customdata = [
+                'eventname' => 'questionchanged',
+                'courseid' => $this->course->id,
+                'submitter' => get_admin(),
+                'recipient' => $this->student2,
+                'messagedata' => $notifydata,
+                'questionurl' => $notifydata->questionurl,
+                'questionname' => $notifydata->questionname,
+        ];
+
+        // Execute the cron.
+        ob_start();
+        cron_setup_user();
+        $cron = new \mod_studentquiz\task\send_no_digest_notification_task();
+        $cron->set_custom_data($customdata);
+        $cron->set_component('mod_studentquiz');
+        $cron->execute();
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertContains('Sending notification for StudentQuiz for question ' .
+                $question->name . ' to ' .
+                $notifydata->recepientname, $output);
+    }
+
+    /**
+     * Test send_no_digest_notification_task
+     */
+    public function test_send_digest_notification_task() {
+        global $DB;
+        date_default_timezone_set('UTC');
+
+        $question = $DB->get_record('question', ['id' => $this->questions[0]->id],
+                'id, name, timemodified, createdby, modifiedby');
+        $notifydata = mod_studentquiz_prepare_notify_data($question, $this->student1, get_admin(), $this->course,
+                get_coursemodule_from_id('studentquiz', $this->cmid));
+
+        $customdata = [
+                'eventname' => 'questionchanged',
+                'courseid' => $this->course->id,
+                'submitter' => get_admin(),
+                'recipient' => $this->student2,
+                'messagedata' => $notifydata,
+                'questionurl' => $notifydata->questionurl,
+                'questionname' => $notifydata->questionname,
+        ];
+
+        $notificationqueue = new stdClass();
+        $notificationqueue->studentquizid = $notifydata->moduleid;
+        $notificationqueue->content = serialize($customdata);
+        $notificationqueue->recipientid = $this->student2->id;
+        $notificationqueue->timetosend = strtotime('-1 day', strtotime(date('Y-m-d')));
+        $DB->insert_record('studentquiz_notification', $notificationqueue);
+
+        // Execute the cron.
+        ob_start();
+        cron_setup_user();
+        $cron = new \mod_studentquiz\task\send_digest_notification_task();
+        $cron->set_component('mod_studentquiz');
+        $cron->execute();
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertContains('Sending digest notification for StudentQuiz', $output);
+        $this->assertContains('Sent 1 messages!', $output);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'mod_studentquiz';
-$plugin->version      = 2020050100;
+$plugin->version      = 2020050404;
 $plugin->release      = 'v4.2.0';
 $plugin->requires     = 2018051700; // Version MOODLE_35, 3.5.0+.
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
Hi @frankkoch,
I have a enhancement as below:

---------------------------------------------------
Currently in StudentQuiz, you can add students/tutors to the Notification permissions, and they will receive an email every time a question is approved/deleted/edited. 
We might want to start using this feature at some point, but currently these settings could lead to some poor tutors receiving hundreds of emails.

So in forums (specifically, our ForumNG), we have settings that sends a single 'daily summary' (for days where there is at >1 action). This means that on busy days, our users receive a single summary email, than notifications for each individual action.

I believe that there is also a weekly as well as daily summary option.

So strategically, it would be good to implement a similar setting for StudentQuiz (at the point of Student-Quiz set-up) called "Notification settings" (which would be an additional section), with a drop down for:

    "No digest (single email per action)".
    "Daily digest".
    "Weekly digest".

**Email format**
From: [server email address]
To: [user]

<Body>
This is your [daily|weekly] digest of notifications for the "[Activity name]" StudentQuiz activity, available here: [Activity URL].

=====================================================================

---------------------------------------------------------------------
[Notification 01 title, time/date]
---------------------------------------------------------------------
[Any associated data]

---------------------------------------------------------------------
[Notification 02 title, time/date]
---------------------------------------------------------------------
[Any associated data]

</Body>

**Times**

    Individual actions: should be picked up by cron, which currently runs every 15 minutes. This is good enough.
    Daily digests: The summary of the previous day. Basically 00h:00m:00s through to 23h:59m:59s of system time (which for us at the OU is GMT/BST). Unless there is a clever way to adapt for students studying in France at GMT+1 which they've changed their settings for in their profile, they'll receive a report for 01h:00m:00s - 00h:59m:59s their time.
    Weekly digests: while you could perhaps check the study planner for the start-day-of-the-week, it might not be set (e.g. topic-based mode). Therefore, it seems better to set the 'Start of the week' in the activity settings (default = Monday as most of the world considers this day 1 and Sunday day 7, and those who don't can set Sunday as day 1. If the activity runs mid-week, then I guess this actually creates a lot of flexibility. OK, I am now thoroughly convinced that we need this option). 

If the digest settings are changed once there are notifications queued, the system will send a summary digest to all users as soon as possible and then change to the new notification behaviour.

---------------------------------------------------

Thanks,
