### PR TITLE
Add crumbtrail when taking quizzes

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -200,6 +200,13 @@ $title = format_string($question->name);
 $PAGE->set_title($cm->name);
 $PAGE->set_heading($cm->name);
 $PAGE->set_context($context);
+
+// Render nav bar.
+$navinfo = new stdClass();
+$navinfo->current = $slot;
+$navinfo->total = $questionscount;
+$PAGE->navbar->add(get_string('nav_question_no', 'studentquiz', $navinfo));
+
 echo $OUTPUT->header();
 
 $info = new stdClass();

--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -194,6 +194,7 @@ $string['mylastattempt_column_name'] = 'My Last Attempt';
 $string['myrate_column_name'] = 'My Rating';
 $string['nav_export'] = 'Export';
 $string['nav_import'] = 'Import';
+$string['nav_question_no'] = 'Question {$a->current} of {$a->total}';
 $string['needtoallowatleastoneqtype'] = 'You need to allow at least one question type';
 $string['next_button'] = 'Next';
 $string['nocommenthistoryexist'] = 'There is no comment history yet for this comment.';


### PR DESCRIPTION
Hi Frank,
Currently when you take a quiz in StudentQuiz, there is no further 'level' in the crumbtrail beyond the activity's 'main' page:

![image](https://user-images.githubusercontent.com/11548406/84632957-e89f0400-af19-11ea-8ae6-0fcb6fb5db48.png)

The feedback is essentially that this looks 'odd', and it would be expected that "Question [1|2] of 2" would be the logical 'level' in the crumbtrail.

Clicking on the activity name ("Example studentquiz (publish automatically" in the above) should continue taking you back to the 'main' page.

Thanks,