### PR TITLE
The deleted text/Comment text is shifting when click on Expand/Collapse icon

### DIFF
--- a/templates/comment.mustache
+++ b/templates/comment.mustache
@@ -112,7 +112,7 @@
                             {{{content}}}
                         {{/expanded}}
                         {{^expanded}}
-                            {{{shortcontent}}}
+                            <p>{{{shortcontent}}}</p>
                         {{/expanded}}
                     </div>
                 </div>
@@ -183,7 +183,7 @@
                         {{{content}}}
                     {{/expanded}}
                     {{^expanded}}
-                        {{{shortcontent}}}
+                        <p>{{{shortcontent}}}</p>
                     {{/expanded}}
                 </div>
                 {{#canedit}}


### PR DESCRIPTION
Keep the default margin of the *p* tag