### PR TITLE
Improve role sync performance. Fixes #306

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -51,6 +51,10 @@ $slot = required_param('slot', PARAM_INT);
 $attempt = $DB->get_record('studentquiz_attempt', array('id' => $attemptid));
 
 $context = context_module::instance($cm->id);
+
+// Check to see if any roles setup has been changed since we last synced the capabilities.
+\mod_studentquiz\access\context_override::ensure_permissions_are_right($context);
+
 $studentquiz = mod_studentquiz_load_studentquiz($cmid, $context->id);
 
 global $USER;

--- a/classes/access/context_override.php
+++ b/classes/access/context_override.php
@@ -119,24 +119,23 @@ class context_override {
     }
 
     /**
-     * Add context specific capabilities as overrides to all roles assigned to this context tree to the given context.
-     * All other capability overrides not given in relation are removed!
+     * Add context specific question capability overrides to match the StudentQuiz capabilities each role has.
+     *
+     * As well as assigning the capabilities that are needed according to the relation array,
+     * any capability that is mentioned in the array will be removed from roles that don't need it.
+     *
      * Warning: This functions assigns and unassigns capabilities. If this function is called from a
      * capability_[un]assigned event, it will trigger that event again if it finds out that changes have to be made. The
      * outcome of this chain of events may be uncontrollable and thus should be avoided or filtered very carefully!
-     * Caveat: If this function is called and a role is not anymore present in the enrolment, its capability overrides
-     * are not removed. This is due to how this function gathers the roles in the context so you have a few unused and
-     * inactive capability overrides. If that role is added back, the relation is ensured again.
      *
-     * @param context $context to apply the override
+     * @param context $context where to apply the overrides.
      * @param array $relation where keys are needed capabilities and its values an array of capabilities to override
      */
     private static function ensure_relation(context $context, array $relation) {
-        global $CFG;
+        global $DB;
 
-        // Get a list of roles assigned to this context tree (since it is possible that there are no roles assigned
-        // directly to the context, includeparents is set to true).
-        $roles = get_roles_used_in_context($context, true);
+        // We fix all roles here. That way, we don't have to worry about roles being assigned or unassigned in future.
+        $roles = $DB->get_records('role');
         foreach ($roles as $role) {
             // Get the list of resolved capabilities of this role in this exact context (includes overrides). This list
             // represents which capabilities are given to the role.

--- a/commenthistory.php
+++ b/commenthistory.php
@@ -50,6 +50,9 @@ require_login($cm->course, false, $cm);
 
 // Load context.
 $context = context_module::instance($cm->id);
+
+// Check to see if any roles setup has been changed since we last synced the capabilities.
+\mod_studentquiz\access\context_override::ensure_permissions_are_right($context);
 $studentquiz = mod_studentquiz_load_studentquiz($cm->id, $context->id);
 
 // Comment access check.

--- a/db/caches.php
+++ b/db/caches.php
@@ -15,21 +15,23 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Defines the version and other meta-info about the plugin
- *
- * Setting the $plugin->version to 0 prevents the plugin from being installed.
- * See https://docs.moodle.org/dev/version.php for more info.
+ * StudentQuiz cache definitions.
  *
  * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch) <your@email.address>
+ * @category   cache
+ * @copyright  2021 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component    = 'mod_studentquiz';
-$plugin->version      = 2021021800;
-$plugin->release      = 'v4.4.1';
-$plugin->requires     = 2018051700; // Version MOODLE_35, 3.5.0+.
-$plugin->maturity     = MATURITY_STABLE;
-$plugin->cron         = 0;
+$definitions = [
+    // This MUST NOT be a local cache, sorry cluster lovers.
+    'permissionssync' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => true,
+        'staticacceleration' => true,
+        'staticaccelerationsize' => 30,
+    ],
+];

--- a/db/events.php
+++ b/db/events.php
@@ -46,13 +46,5 @@ $observers = [
                 'eventname' => '\core\event\capability_unassigned',
                 'callback' => 'mod_studentquiz_observer::capability_unassigned',
         ],
-        [
-                'eventname' => '\core\event\role_assigned',
-                'callback' => 'mod_studentquiz_observer::role_assigned',
-        ],
-        [
-                'eventname' => '\core\event\role_unassigned',
-                'callback' => 'mod_studentquiz_observer::role_unassigned',
-        ],
         // I assume course_module_deleted removes anyway all capability overrides, so not added here.
 ];

--- a/db/events.php
+++ b/db/events.php
@@ -54,9 +54,5 @@ $observers = [
                 'eventname' => '\core\event\role_unassigned',
                 'callback' => 'mod_studentquiz_observer::role_unassigned',
         ],
-        [
-                'eventname' => '\core\event\course_module_created',
-                'callback' => 'mod_studentquiz_observer::course_module_created',
-        ],
         // I assume course_module_deleted removes anyway all capability overrides, so not added here.
 ];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -813,15 +813,5 @@ function xmldb_studentquiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2020051200, 'studentquiz');
     }
 
-    // From now on events take care for all context specific capability overrides. Since the current state
-    // can be incorrect, apply the overrides once for all StudentQuizzes.
-    if ($oldversion < 2020081700) {
-        require_once(__DIR__ . '/../classes/observer.php');
-
-        mod_studentquiz_observer::module_update_backwardsfix_capability_override();
-
-        upgrade_mod_savepoint(true, 2020081700, 'studentquiz');
-    }
-
     return true;
 }

--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -47,6 +47,7 @@ $string['before_answering_end_date'] = 'This StudentQuiz closes for answering on
 $string['before_answering_start_date'] = 'Open for answering from {$a}.';
 $string['before_submission_end_date'] = 'This StudentQuiz closes for question submission on {$a}.';
 $string['before_submission_start_date'] = 'Open for question submission from {$a}.';
+$string['cachedef_permissionssync'] = 'StudentQuiz permission synchronisation tracking';
 $string['cannotcapturecommenthistory'] = 'Can not capture comment history record';
 $string['changeselectedsstate'] = 'Change the state of the following questions:<br /><br />{$a}';
 $string['collapseall'] = 'Collapse all comments';

--- a/locallib.php
+++ b/locallib.php
@@ -73,6 +73,7 @@ function mod_studentquiz_load_studentquiz($cmid, $contextid) {
             $context = \context::instance_by_id($contextid);
             $studentquiz->category = question_make_default_categories(array($context));
             $studentquiz->categoryid = $studentquiz->category->id;
+
             return $studentquiz;
         } else {
             return $studentquiz;

--- a/preview.php
+++ b/preview.php
@@ -46,6 +46,10 @@ require_login($module->course, false, $module);
 
 // Load context.
 $context = context_module::instance($module->id);
+
+// Check to see if any roles setup has been changed since we last synced the capabilities.
+\mod_studentquiz\access\context_override::ensure_permissions_are_right($context);
+
 $studentquiz = mod_studentquiz_load_studentquiz($module->id, $context->id);
 
 // Lookup question.

--- a/reportlib.php
+++ b/reportlib.php
@@ -179,8 +179,12 @@ class mod_studentquiz_report {
         }
 
         $this->context = context_module::instance($this->cm->id);
+
         $this->userid = $USER->id;
         $this->availablequestions = mod_studentquiz_count_questions($cmid);
+
+        // Check to see if any roles setup has been changed since we last synced the capabilities.
+        \mod_studentquiz\access\context_override::ensure_permissions_are_right($this->context);
     }
 
     /**

--- a/tests/permissions_test.php
+++ b/tests/permissions_test.php
@@ -24,6 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die('Direct Access is forbidden!');
 
+use mod_studentquiz\access\context_override;
+
 /**
  * Unit tests permission namespace.
  *
@@ -31,7 +33,7 @@ defined('MOODLE_INTERNAL') || die('Direct Access is forbidden!');
  * @copyright  2020 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_permissions extends advanced_testcase {
+class mod_studentquiz_permissions_testcase extends advanced_testcase {
 
     /**
      * Setup test
@@ -87,8 +89,10 @@ class mod_studentquiz_permissions extends advanced_testcase {
         // Events take over for applying context_override::ensure_relation. Looks like events in unit tests are only
         // processed in Moodle 38 and later, so we have to manually call the context capability overrides.
         if ($CFG->branch < 38) {
-            mod_studentquiz_observer::module_test_backwardsfix_capability_override($studentquiz->coursemodule);
+            context_override::roles_setup_has_changed();
         }
+        context_override::ensure_permissions_are_right($contextstudentquiz);
+
         $this->assertTrue(has_capability('moodle/question:editall', $contextstudentquiz));
 
         // Then we remove that capability again and the user has not anymore the context specific capability.
@@ -96,8 +100,9 @@ class mod_studentquiz_permissions extends advanced_testcase {
         // Events take over for applying context_override::ensure_relation. Looks like events in unit tests are only
         // processed in Moodle 38 and later, so we have to manually call the context capability overrides.
         if ($CFG->branch < 38) {
-            mod_studentquiz_observer::module_test_backwardsfix_capability_override($studentquiz->coursemodule);
+            context_override::roles_setup_has_changed();
         }
+        context_override::ensure_permissions_are_right($contextstudentquiz);
         $this->assertFalse(has_capability('moodle/question:editall', $contextstudentquiz));
     }
 }

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'mod_studentquiz';
-$plugin->version      = 2021021800;
+$plugin->version      = 2021021900;
 $plugin->release      = 'v4.4.1';
 $plugin->requires     = 2018051700; // Version MOODLE_35, 3.5.0+.
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
Before this comment, as soon as any role was changed, the permissions for
all student-quizzes were changed.

After this, when the roles change, then we note that time in a cache.

Then, when a user tries to access a StudentQuiz, if the roles have
changed since we last synced permissions for this StudentQuiz,
then we re-sync them (and note the fact in the cache).

Because of the way the cache is used, if the caches are purged, then
we will re-sync the permissions for each StudentQuiz the next time a
user tries to access it.