### PR TITLE
Added support for SQL Server 2017 and newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Supported and tested with:
 
 - Moodle 3.5, 3.7, 3.8, 3.9
 - PHP 7.1, 7.2, 7.3, 7.4
-- Databases: MySQL, MariaDB, PostgreSQL
+- Databases: MySQL, MariaDB, PostgreSQL, SQL Server 2017
 - Browsers: Firefox, Chrome
 
 Refer to the Moodle release notes for the minimum requirements for PHP and the databases. Other modern browsers should

--- a/classes/local/db.php
+++ b/classes/local/db.php
@@ -42,12 +42,18 @@ class db {
     const DBFAMILY_POSTGRES = 'postgres';
 
     /**
+     * @var string DBFAMILY_MSSQL
+     */
+    const DBFAMILY_MSSQL = 'mssql';
+
+    /**
      * group_concat is a helper function to extend the database abstraction. It returns the function used by the current
      * selected database driver for concatenating a column when the query is grouped.
      *
      * - MySQL: GROUP_CONCAT (https://dev.mysql.com/doc/refman/8.0/en/group-by-functions.html)
      * - MariaDB: GROUP_CONCAT (https://mariadb.com/kb/en/group_concat/)
      * - PostgreSQL: https://www.postgresql.org/docs/9.0/functions-aggregate.html
+     * - SQL Server: https://docs.microsoft.com/en-us/sql/t-sql/functions/string-agg-transact-sql?view=sql-server-2017
      *
      * @param string $field name
      * @return string
@@ -60,6 +66,7 @@ class db {
             case self::DBFAMILY_MYSQL:
                 return "GROUP_CONCAT($field)";
             case self::DBFAMILY_POSTGRES:
+            case self::DBFAMILY_MSSQL:
                 return "STRING_AGG($field, ',')";
             default:
                 throw new \coding_exception("Unsupported database family: $family");

--- a/locallib.php
+++ b/locallib.php
@@ -905,7 +905,7 @@ function mod_studentquiz_helper_attempt_stat_joins($excluderoles=array()) {
                            AND sqq.hidden = 0
                            AND q.parent = 0
                            AND sq.coursemodule = :cmid4
-                  GROUP BY creator
+                  GROUP BY q.createdby
                   ) creators ON creators.creator = u.id
         -- Approved questions.
         LEFT JOIN (
@@ -921,7 +921,7 @@ function mod_studentquiz_helper_attempt_stat_joins($excluderoles=array()) {
                             AND q.parent = 0
                             AND sqq.hidden = 0
                             AND sq.coursemodule = :cmid5
-                   GROUP BY creator
+                   GROUP BY q.createdby
                    ) approvals ON approvals.creator = u.id
         -- Average of Average Rating of own questions.
         LEFT JOIN (


### PR DESCRIPTION
Since SQL Server 2017 and newer has the `STRING_AGG` function, it can be treated like PostgreSQL. Also, SQL Server is not able to `GROUP BY` column aliases.