### PR TITLE
The lang string is misspelled

### DIFF
--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -502,5 +502,5 @@ $string['studentquizname_help'] = 'The name of this StudentQuiz Activity';
 $string['submissionendbeforestart'] = 'Submissions deadline can not be specified before the open for submissions date';
 $string['tags'] = 'Tags';
 $string['unapprove'] = 'Unapprove';
-$string['notshowratingcomment'] = 'Note: Rating and comment is not avaiable in Preview mode on your own question';
+$string['notshowratingcomment'] = 'Note: Rating and comment is not available in Preview mode on your own question';
 $string['studentquiz:emailnotifyquestion'] = 'Email notify question';

--- a/tests/behat/preview_question.feature
+++ b/tests/behat/preview_question.feature
@@ -83,7 +83,7 @@ Feature: Preview a question as a student
     And I switch to "questionpreview" window
     And I should not see "Rate"
     And I should not see "Add comment"
-    And I should see "Note: Rating and comment is not avaiable in Preview mode on your own question"
+    And I should see "Note: Rating and comment is not available in Preview mode on your own question"
 
   @javascript @_switch_window
   Scenario: User with higher student's role post new question, and he/she can comment or rating on new's one


### PR DESCRIPTION
Hi Frank,

If you use 'View as Student' to preview a question, "available" is misspelled. I have fixed the typo. Could you please help me to review it?

Thanks.