### PR TITLE
StudentQuiz: Where we print user names, make them links to the profile

### DIFF
--- a/classes/commentarea/comment.php
+++ b/classes/commentarea/comment.php
@@ -421,23 +421,27 @@ class comment {
             // If this comment is deleted and user don't have permission to view then we hide following information.
             $object->title = '';
             $object->authorname = '';
+            $object->authorprofileurl = '';
             $object->posttime = '';
-            $object->deleteuser->firstname = '';
-            $object->deleteuser->lastname = '';
+            $object->deleteuser->fullname = '';
+            $object->deleteuser->profileurl = '';
         } else {
             if ($container->can_view_username() || $this->is_creator()) {
-                $object->authorname = $this->get_user()->fullname;
+                $user = $this->get_user();
+                $object->authorname = $user->fullname;
+                $object->authorprofileurl = $user->profileurl->out();
             } else {
                 $object->authorname = get_string('anonymous_user_name', 'mod_studentquiz', $object->rownumber);
+                $object->authorprofileurl = '';
             }
             $object->posttime = userdate($this->get_created(), $this->strings['timeformat']);
             if ($this->is_deleted()) {
                 $deleteuser = $this->get_delete_user();
-                $object->deleteuser->firstname = $deleteuser->firstname;
-                $object->deleteuser->lastname = $deleteuser->lastname;
+                $object->deleteuser->fullname = $deleteuser->fullname;
+                $object->deleteuser->profileurl = $deleteuser->profileurl->out();
             } else {
-                $object->deleteuser->firstname = '';
-                $object->deleteuser->lastname = '';
+                $object->deleteuser->fullname = '';
+                $object->deleteuser->profileurl = '';
             }
         }
         $object->deleted = $this->is_deleted();
@@ -455,13 +459,22 @@ class comment {
             if ($this->data->userid == $comment->usermodified) {
                 $editedcommenthistoryuser = get_string('comment_author', 'mod_studentquiz');
             } else if ($container->can_view_username()) {
-                $editedcommenthistoryuser = fullname(\core_user::get_user($comment->usermodified));
+                $user = \core_user::get_user($comment->usermodified);
+                $editedcommenthistoryuser = fullname($user);
+                $editedcommenthistoryuserurl = utils::get_user_profile_url($user->id,
+                    $this->get_container()->get_course()->id)->out();
             } else {
                 $editedcommenthistoryuser = get_string('anonymous_user_name', 'mod_studentquiz', $object->rownumber);
             }
 
             if ($object->deleted) {
                 $object->commenthistorymetadata = userdate($this->get_latest_edited_time(), $this->strings['timeformat']);
+            } else if (!empty($editedcommenthistoryuserurl)) {
+                $object->commenthistorymetadata = get_string('editedcommenthistorywithuserlink', 'mod_studentquiz', [
+                    'lastesteditedcommentauthorname' => $editedcommenthistoryuser,
+                    'lastededitedcommenttime' => userdate($this->get_latest_edited_time(), $this->strings['timeformat']),
+                    'lastesteditedcommentauthorprofileurl' => $editedcommenthistoryuserurl
+                ]);
             } else {
                 $object->commenthistorymetadata = get_string('editedcommenthistory', 'mod_studentquiz', [
                         'lastesteditedcommentauthorname' => $editedcommenthistoryuser,

--- a/classes/commentarea/container.php
+++ b/classes/commentarea/container.php
@@ -571,6 +571,7 @@ class container {
             $users = $DB->get_records_sql($query, $params);
             foreach ($users as $user) {
                 $user->fullname = fullname($user);
+                $user->profileurl = utils::get_user_profile_url($user->id, $this->get_course()->id);
                 $this->userlist[$user->id] = $user;
             }
         }
@@ -583,6 +584,7 @@ class container {
      */
     public function add_user_to_user_list($userid) {
         $user = \core_user::get_user($userid);
+        $user->profileurl = utils::get_user_profile_url($user->id, $this->get_course()->id);
         $user->fullname = fullname($user);
         $this->userlist[$user->id] = $user;
     }
@@ -906,6 +908,7 @@ class container {
     public function extract_comment_history_to_render($commenthistories): array {
         $outputresults = [];
         $userinfocacheset = [];
+        $profileurl = [];
         foreach ($commenthistories as $commenthistory) {
             $instance = new stdClass();
             $instance->id = $commenthistory->id;
@@ -916,12 +919,15 @@ class container {
                 if ($this->can_view_username() || $this->get_user()->id == $commenthistory->userid) {
                     $user = \core_user::get_user($commenthistory->userid);
                     $instance->authorname = fullname($user, true);
+                    $instance->authorprofileurl = utils::get_user_profile_url($user->id, $this->get_course()->id);
                 } else {
                     $instance->authorname = get_string('anonymous_user_name', 'mod_studentquiz', $instance->rownumber);
                 }
                 $userinfocacheset[$commenthistory->userid] = $instance->authorname;
+                $profileurl[$commenthistory->userid] = $instance->authorprofileurl;
             } else {
                 $instance->authorname = $userinfocacheset[$commenthistory->userid];
+                $instance->authorprofileurl = $profileurl[$commenthistory->userid];
             }
 
             $outputresults[] = $instance;

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -31,6 +31,7 @@ use core_courseformat\output\local\state\cm;
 use external_value;
 use external_single_structure;
 use mod_studentquiz\commentarea\comment;
+use moodle_url;
 
 /**
  * Class that holds utility functions used by mod_studentquiz.
@@ -84,12 +85,13 @@ style5 = html';
                 'shortcontent' => new external_value(PARAM_RAW, 'Comment short content'),
                 'numberofreply' => new external_value(PARAM_INT, 'Number of reply for this comment'),
                 'authorname' => new external_value(PARAM_TEXT, 'Author of this comment'),
+                'authorprofileurl' => new external_value(PARAM_TEXT, 'Profile url author of this comment'),
                 'posttime' => new external_value(PARAM_RAW, 'Comment create time'),
                 'deleted' => new external_value(PARAM_BOOL, 'Comment is deleted or not'),
                 'deletedtime' => new external_value(PARAM_RAW, 'Comment edited time, if not deleted return 0'),
                 'deleteuser' => new external_single_structure([
-                        'firstname' => new external_value(PARAM_TEXT, 'Delete user first name'),
-                        'lastname' => new external_value(PARAM_TEXT, 'Delete user last name'),
+                        'fullname' => new external_value(PARAM_TEXT, 'Delete user first name'),
+                        'profileurl' => new external_value(PARAM_TEXT, 'Delete user last name'),
                 ]),
                 'candelete' => new external_value(PARAM_BOOL, 'Can delete this comment or not.'),
                 'canreply' => new external_value(PARAM_BOOL, 'Can reply this comment or not.'),
@@ -555,5 +557,19 @@ style5 = html';
         global $DB;
 
         return $DB->get_field('studentquiz_question', 'state', ['questionid' => $question->id]);
+    }
+
+    /**
+     * Get the url to view an user's profile.
+     *
+     * @param int $userid The userid
+     * @param int $courseid The courseid
+     * @return moodle_url
+     */
+    public static function get_user_profile_url(int $userid, int $courseid): moodle_url {
+        return new moodle_url('/user/view.php', [
+            'id' => $userid,
+            'course' => $courseid
+        ]);
     }
 }

--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -74,7 +74,7 @@ $string['difficulty_level_column_name'] = 'Difficulty';
 $string['difficulty_title'] = 'Difficulty bar';
 $string['delete'] = 'Delete';
 $string['deletecomment'] = 'Delete comment';
-$string['deletedbyuser'] = 'This post was deleted by {$a->user} on {$a->date}.';
+$string['deletedbyuser'] = 'This post was deleted by <a href="{$a->profileurl}" >{$a->fullname}</a> on {$a->date}.';
 $string['deletedbyauthor'] = 'This post was deleted on {$a}.';
 $string['deletedcomment'] = 'Deleted post.';
 $string['describe_already_deleted'] = 'This comment is already deleted.';
@@ -85,6 +85,7 @@ $string['editcomment'] = 'Edit comment';
 $string['emailautomationnote'] = 'Please note that this is an automated system message – this email address is not monitored.';
 $string['editedcomment_last_edit'] = 'Last edited: ';
 $string['editedcommenthistory'] = 'Edited by the {$a->lastesteditedcommentauthorname} on {$a->lastededitedcommenttime}';
+$string['editedcommenthistorywithuserlink'] = 'Edited by the <a href="{$a->lastesteditedcommentauthorprofileurl}">{$a->lastesteditedcommentauthorname}</a> on {$a->lastededitedcommenttime}';
 $string['editedcommenthistorylinktext'] = 'History';
 $string['emailcommentaddedbody'] = 'Dear {$a->recepientname},
 

--- a/renderer.php
+++ b/renderer.php
@@ -172,11 +172,12 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         foreach ($ranking as $row) {
             if ($currentuserid == $row->userid || !$anonymise) {
                 $author = user_get_users_by_id(array($row->userid))[$row->userid];
-                $name = fullname($author);
+                $name = html_writer::link(utils::get_user_profile_url($author->id, $this->page->course->id), fullname($author));
             } else {
                 $name = $anonymname;
             }
-            $rows[] = \html_writer::div($rank . '. ' . $name .
+            $rankname = \html_writer::div($rank . '. ' . $name);
+            $rows[] = \html_writer::div($rankname .
                 html_writer::span(html_writer::tag('b' , round($row->points)),
                     '', array('style' => 'float: right;')));
             $rank++;
@@ -391,7 +392,9 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         } else {
             $author = core_user::get_user($question->createdby);
             if ($author) {
-                $output .= html_writer::tag('span', fullname($author));
+                $userprofilelink = html_writer::link(utils::get_user_profile_url($author->id,
+                    $this->page->course->id), fullname($author));
+                $output .= html_writer::tag('span', $userprofilelink);
             } else {
                 // Cannot find the user. Leave it blank.
                 $output .= html_writer::tag('span', '');
@@ -1961,7 +1964,7 @@ class mod_studentquiz_ranking_renderer extends mod_studentquiz_renderer {
                 }
             }
             $author = user_get_users_by_id(array($ur->userid))[$ur->userid];
-            $username = fullname($author);
+            $username = html_writer::link(utils::get_user_profile_url($author->id, $this->page->course->id), fullname($author));
             if ($report->is_anonymized() && $ur->userid != $userid) {
                 $username = get_string('creator_anonym_fullname', 'studentquiz');
             }

--- a/templates/comment.mustache
+++ b/templates/comment.mustache
@@ -32,8 +32,8 @@
         "canviewdeleted": true,
         "canreply": true,
         "deleleuser": {
-            "firstname": "",
-            "lastname": ""
+            "fullname": "",
+            "profileurl": ""
         },
         "deleted": false,
         "deletedtime": 0,
@@ -41,6 +41,7 @@
         "rownumber": 1,
         "root": true,
         "authorname": "Teacher",
+        "authorprofileurl": "",
         "posttime": "6 December 2019, 4:06 PM",
         "canedit": true,
         "replies": [
@@ -56,8 +57,8 @@
                 "canviewdeleted": true,
                 "canreply": true,
                 "deleleuser": {
-                    "firstname": "",
-                    "lastname": ""
+                    "fullname": "",
+                    "profileurl": ""
                 },
                 "deleted": false,
                 "deletedtime": 0,
@@ -65,6 +66,7 @@
                 "rownumber": 2,
                 "root": false,
                 "authorname": "Teacher",
+                "authorprofileurl": "",
                 "posttime": "6 December 2019, 4:08 PM",
                 "canedit": true,
                 "allowselfcommentrating": true
@@ -81,7 +83,12 @@
                 <div class="studentquiz-comment-author">
                     <span class="studentquiz-comment-postdate">{{posttime}}</span>
                     <span> | </span>
-                    {{authorname}}
+                    {{#authorprofileurl}}
+                        <a href={{authorprofileurl}}>{{authorname}}</a>
+                    {{/authorprofileurl}}
+                    {{^authorprofileurl}}
+                        {{authorname}}
+                    {{/authorprofileurl}}
                     {{#root}}
                         {{#expanded}}
                             <a class="studentquiz-comment-collapselink" href="#" title="{{#str}} collapsecomment, mod_studentquiz {{/str}}">
@@ -103,7 +110,8 @@
                         <strong>{{#str}} deletedcomment, mod_studentquiz{{/str}}</strong>
                         {{#str}}
                             deletedbyuser, mod_studentquiz, {
-                            "user": {{# quote }} {{deleteuser.firstname}} {{deleteuser.lastname}} {{/ quote }},
+                            "fullname": {{# quote }} {{deleteuser.fullname}} {{deleteuser.profilelink}} {{/ quote }},
+                            "profileurl": {{# quote }} {{deleteuser.profileurl}} {{/ quote }},
                             "date": {{# quote }}{{ deletedtime }}{{/ quote }}
                             }
                         {{/str}}
@@ -169,7 +177,12 @@
             <div class="studentquiz-comment-author">
                 <span class="studentquiz-comment-postdate">{{posttime}}</span>
                 <span> | </span>
-                {{authorname}}
+                {{#authorprofileurl}}
+                    <a href={{authorprofileurl}}>{{authorname}}</a>
+                {{/authorprofileurl}}
+                {{^authorprofileurl}}
+                    {{authorname}}
+                {{/authorprofileurl}}
                 {{#root}}
                     {{#expanded}}
                         <a class="studentquiz-comment-collapselink" href="#" title="{{#str}} collapsecomment, mod_studentquiz {{/str}}">
@@ -198,7 +211,7 @@
                 {{#canedit}}
                     {{#isedithistory}}
                         <div class="studentquiz-comment-history">
-                            {{commenthistorymetadata}}
+                            {{{commenthistorymetadata}}}
                             (<a href="#"
                                 onclick="window.open('{{{ commenthistorylink }}}', '{{#str}} commenthistory, mod_studentquiz {{/str}}', 'scrollbars=1,resizable=1,width=800,height=600'); return false;"
                                 target="_blank">{{#str}} editedcommenthistorylinktext, mod_studentquiz {{/str}}</a>)

--- a/templates/comment_history_element.mustache
+++ b/templates/comment_history_element.mustache
@@ -32,7 +32,12 @@
         <div class="studentquiz-comment-author">
             <span class="studentquiz-comment-postdate">{{ posttime }}</span>
             <span> | </span>
-            {{ authorname }}
+            {{#authorprofileurl}}
+                <a href={{authorprofileurl}}>{{authorname}}</a>
+            {{/authorprofileurl}}
+            {{^authorprofileurl}}
+                {{authorname}}
+            {{/authorprofileurl}}
         </div>
         <div class="studentquiz-comment-text">
             {{{ content }}}

--- a/templates/comments.mustache
+++ b/templates/comments.mustache
@@ -40,8 +40,8 @@
                 "canviewdeleted": true,
                 "canreply": true,
                 "deleleuser": {
-                    "firstname": "",
-                    "lastname": ""
+                    "fullname": "",
+                    "profileurl": ""
                 },
                 "deleted": false,
                 "deletedtime": 0,
@@ -49,6 +49,7 @@
                 "rownumber": 1,
                 "root": true,
                 "authorname": "Teacher",
+                "authorprofileurl": "",
                 "posttime": "6 December 2019, 4:06 PM",
                 "canedit": true,
                 "replies": [
@@ -64,8 +65,8 @@
                         "canviewdeleted": true,
                         "canreply": true,
                         "deleleuser": {
-                            "firstname": "",
-                            "lastname": ""
+                            "fullname": "",
+                            "profileurl": ""
                         },
                         "deleted": false,
                         "deletedtime": 0,
@@ -73,6 +74,7 @@
                         "rownumber": 2,
                         "root": false,
                         "authorname": "Teacher",
+                        "authorprofileurl": "",
                         "posttime": "6 December 2019, 4:08 PM",
                         "canedit": true
                     }


### PR DESCRIPTION
Hi @timhunt ,

In this commit, I have added a link to the profile, where we print user names. I have found out where we print user and list below:

- Ranking block
- Ranking page
- 'Created by' column in the question list.
- Comments
- History Comments

On the ranking blocks:
<img width="281" alt="Ranking block" src="https://user-images.githubusercontent.com/32395146/138438825-6d77e177-e2a5-48e6-8022-1e2d2daeadc2.png">

On the ranking page:
<img width="1434" alt="Ranking page" src="https://user-images.githubusercontent.com/32395146/138438866-2c90db59-aea5-49e1-b042-55095158dfd5.png">

On the 'Created by' column in the question list.
<img width="1113" alt="Questionlist" src="https://user-images.githubusercontent.com/32395146/138438985-e2f16288-5c97-45e4-8edc-4215fe941ad6.png">

On the Comments
<img width="1421" alt="Comments" src="https://user-images.githubusercontent.com/32395146/138439037-1527f52e-6f14-4682-9084-4678642d963a.png">

In the comments history
<img width="796" alt="Comment history" src="https://user-images.githubusercontent.com/32395146/138439103-3b7e7071-0160-4690-873d-407022f1ccc8.png">


Could you please help me to review it?

Thanks,