### PR TITLE
Fix focus visibility on filter buttons

### DIFF
--- a/classes/question/bank/question_bank_filter.php
+++ b/classes/question/bank/question_bank_filter.php
@@ -341,8 +341,9 @@ class toggle_filter_checkbox extends user_filter_checkbox {
      */
     public function setup_form_in_group(&$mform, &$group) {
         $disableelements = implode(',', $this->disableelements);
-        $linktoggle = \html_writer::tag('a', $this->_label, ['href' => '#', 'class' => 'link-toggle',
-                'title' => $this->helptext, 'for' => 'id_' . $this->_name, 'data-disableelements' => $disableelements]);
+        $linktoggle = \html_writer::tag('a', $this->_label, ['href' => '#', 'class' => 'link-toggle mb-1',
+                'title' => $this->helptext, 'for' => 'id_' . $this->_name, 'data-disableelements' => $disableelements,
+                'role' => 'button']);
         $element = $mform->createElement('checkbox', $this->_name, null, $linktoggle, ['class' => 'toggle']);
 
         if ($this->_advanced) {


### PR DESCRIPTION
The focus visiblity on firefox in not clear, and is not the same in chrome, so I added role button and some margin bottom
![EVOSTDM-2520-b](https://user-images.githubusercontent.com/3305741/138735716-4abe651e-79cd-493a-b643-edab76568e0c.jpg)
.