### PR TITLE
mod_studentquiz: Fix duplicated question categories in course backup

### DIFF
--- a/backup/moodle2/backup_studentquiz_activity_task.class.php
+++ b/backup/moodle2/backup_studentquiz_activity_task.class.php
@@ -50,6 +50,9 @@ class backup_studentquiz_activity_task extends backup_activity_task {
         // Backup studentquiz tables.
         $this->add_step(new backup_studentquiz_activity_structure_step('studentquiz_structure', 'studentquiz.xml'));
 
+        // Clean backup_temp_ids table of questions.
+        $this->add_step(new backup_delete_temp_questions('clean_temp_questions'));
+
         // Backup question categories.
         $this->add_step(new backup_calculate_question_categories('activity_question_categories'));
     }


### PR DESCRIPTION
I still need to work out how to reproduce the issue manually, without sharing any of our real course backups, but under certain conditions we have found that backups of courses containing mod_studentquiz instances will result in all question categories in the course being duplicated on restore (the duplicates can be seen in the .mbz file).

Debugging has shown that additional course contexts are being included during the calculation of question categories to be included in the backup, and these seem to be the contexts of courses that also include usages of some of the same questions used in the mod_studentquiz instance.

The only reliable way to prevent this seems to be to include the step `new backup_delete_temp_questions('clean_temp_questions')` in backup/moodle2/backup_studentquiz_activity_task.class.php, however it must be included _before_ the step `new backup_calculate_question_categories('activity_question_categories')`, unlike in the core mod_quiz activity where it comes after it.